### PR TITLE
Improvements to the ACL lock for RLAC performance improvements

### DIFF
--- a/server_engine/include/engine.h
+++ b/server_engine/include/engine.h
@@ -952,6 +952,15 @@ typedef void                            * ismEngine_QMgrXidRecordHandle_t;
 
 /**@}*/
 
+//*********************************************************************
+/// @brief DelivererContext
+///
+/// Context for when delivering messages onto a queue
+/// allows for lock optimizations
+//*********************************************************************
+typedef struct ismEngine_DelivererContext_t {
+    ismMessageSelectionLockStrategy_t lockStrategy;
+} ismEngine_DelivererContext_t;
 
 //****************************************************************************
 /** @name Callback functions
@@ -998,6 +1007,7 @@ typedef void (*ismEngine_CompletionCallback_t)(
 /// @param[in]     areaLengths[]    Array of area lengths - some may be 0
 /// @param[in]     pAreaData[]      Pointers to area data - some may be NULL
 /// @param[in]     pConsumerContext Consumer context
+/// @param[in]     delivererContext Context from the deliverer that allows lock optimizations
 ///
 /// @return The callback controls the delivery of further messages.
 /// If the callback returns true and message delivery has not been stopped
@@ -1025,7 +1035,8 @@ typedef bool (*ismEngine_MessageCallback_t)(
     ismMessageAreaType_t            areaTypes[msgAreaCount],
     size_t                          areaLengths[msgAreaCount],
     void *                          pAreaData[msgAreaCount],
-    void *                          pConsumerContext);
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  delivererContext);
 
 
 //****************************************************************************
@@ -1190,7 +1201,8 @@ typedef int32_t (*ismEngine_MessageSelectionCallback_t) (
     void *                          pAreaData[msgAreaCount],
     const char *                    pTopic,
     const void *                    pSelectorRule,
-    size_t                          selectorRuleLen);
+    size_t                          selectorRuleLen,
+    ismMessageSelectionLockStrategy_t * lockStrategy);
 
 
 //****************************************************************************

--- a/server_engine/include/engine.h
+++ b/server_engine/include/engine.h
@@ -1020,6 +1020,11 @@ typedef void (*ismEngine_CompletionCallback_t)(
 /// to disable the consumer and must NOT have be called if the callback
 /// returns true
 ///
+/// The delivererContext is not guarenteed to be passed all the way to delivery. 
+/// It is to hold state for cases where multiple messages are processed as a 
+/// batch in a loop where actions within the loop could cause performance
+/// problems if knowledge is not passed itterations of the loop.
+///
 /// @remark The callback can call other Engine operations, bearing in mind
 /// that the stack must be allowed to unwind.
 //****************************************************************************

--- a/server_engine/src/destination.c
+++ b/server_engine/src/destination.c
@@ -639,8 +639,8 @@ int32_t ieds_publish(ieutThreadData_t *pThreadData,
                                                  putOptions,
                                                  pTran,
                                                  pMessage,
-                                                 IEQ_MSGTYPE_INHERIT,
-                                                 NULL); // no usageCount increment
+                                                 IEQ_MSGTYPE_INHERIT, // no usageCount increment
+                                                 NULL);
 
                         if (msg_rc != OK)
                         {
@@ -792,8 +792,8 @@ int32_t ieds_publish(ieutThreadData_t *pThreadData,
                                                  putOptions,
                                                  pTran,
                                                  pMessage,
-                                                 IEQ_MSGTYPE_INHERIT,
-                                                 &delivererContext ); // no usageCount increment
+                                                 IEQ_MSGTYPE_INHERIT, // no usageCount increment
+                                                 &delivererContext );
 
                         if (msg_rc != OK)
                         {
@@ -853,8 +853,8 @@ int32_t ieds_publish(ieutThreadData_t *pThreadData,
                                                  putOptions,
                                                  pTran,
                                                  pRemoteMsg,
-                                                 IEQ_MSGTYPE_INHERIT,
-                                                 NULL ); // no usageCount increment
+                                                 IEQ_MSGTYPE_INHERIT, // no usageCount increment
+                                                 NULL );
 
                         if (msg_rc != OK) totalRejected++;
                     }
@@ -869,8 +869,8 @@ int32_t ieds_publish(ieutThreadData_t *pThreadData,
                                                  putOptions,
                                                  pTran,
                                                  pRemoteMsg,
-                                                 IEQ_MSGTYPE_INHERIT,
-                                                 NULL); // no usageCount increment
+                                                 IEQ_MSGTYPE_INHERIT, // no usageCount increment
+                                                 NULL);
 
                         if (msg_rc != OK)
                         {

--- a/server_engine/src/engineQueue.c
+++ b/server_engine/src/engineQueue.c
@@ -528,7 +528,7 @@ static int ieq_scheduleCheckWaitersCB(ism_timer_t key, ism_time_t timestamp, voi
     ieutTRACEL(pThreadData, Q, ENGINE_CEI_TRACE, FUNCTION_IDENT "Q=%p\n"
                        , __func__, Q);
 
-    ieq_checkWaiters(pThreadData, Q, NULL);
+    ieq_checkWaiters(pThreadData, Q, NULL, NULL);
 
     //ReduceCount that CALLER of ieq_scheduleCheckWaiters increased
     ieq_reducePreDeleteCount(pThreadData, Q);

--- a/server_engine/src/expiringGet.c
+++ b/server_engine/src/expiringGet.c
@@ -425,7 +425,8 @@ static bool iegiMessageArrived(
         ismMessageAreaType_t            areaTypes[areaCount],
         size_t                          areaLengths[areaCount],
         void *                          pAreaData[areaCount],
-        void *                          pConsumerContext)
+        void *                          pConsumerContext,
+        ismEngine_DelivererContext_t *  _delivererContext )
 {
     ieutThreadData_t *pThreadData = ieut_enteringEngine(hConsumer->pSession->pClient);
     ieutTRACEL(pThreadData, hConsumer,  ENGINE_FNC_TRACE, FUNCTION_ENTRY "(hCons %p)\n", __func__,hConsumer);
@@ -445,7 +446,8 @@ static bool iegiMessageArrived(
                                          , areaTypes
                                          , areaLengths
                                          , pAreaData
-                                         , expGetInfo->pMessageContext);
+                                         , expGetInfo->pMessageContext
+                                         , NULL );
 
     assert(!wantMoreMessages); //We could extend this to allow multiple messages and pass this back and only do following code when
                                //we know (somehow) that we want no more...

--- a/server_engine/src/intermediateQ.c
+++ b/server_engine/src/intermediateQ.c
@@ -1523,7 +1523,7 @@ mod_exit:
 
         // We don't care about any error encountered while attempting
         // to deliver a message to a waiter.
-        (void)ieiq_checkWaiters(pThreadData, (ismEngine_Queue_t *)Q, NULL, NULL);
+        (void)ieiq_checkWaiters(pThreadData, (ismEngine_Queue_t *)Q, NULL, delivererContext);
     }
 
     ieutTRACEL(pThreadData, rc,  ENGINE_FNC_TRACE, FUNCTION_EXIT "rc=%d\n", __func__, rc);
@@ -6822,7 +6822,7 @@ int32_t ieiq_checkWaiters( ieutThreadData_t *pThreadData
                                         , &completeWaiterActions
                                         , &loopAgain
                                         , &storeOps
-                                        , NULL );
+                                        , delivererContext );
 
                     if (storeOps > 0)
                     {

--- a/server_engine/src/intermediateQ.h
+++ b/server_engine/src/intermediateQ.h
@@ -53,7 +53,8 @@ int32_t ieiq_putMessage(ieutThreadData_t *pThreadData,
                         ieqPutOptions_t putOptions,
                         ismEngine_Transaction_t *pTran,
                         ismEngine_Message_t *pMessage,
-                        ieqMsgInputType_t inputMsgTreatment);
+                        ieqMsgInputType_t inputMsgTreatment,
+                        ismEngine_DelivererContext_t * unused);
 // Completes the rehydrate of a queue
 int32_t ieiq_completeRehydrate( ieutThreadData_t *pThreadData, ismQHandle_t Qhdl );
 // Puts a message on a queue during restart
@@ -121,7 +122,8 @@ void ieiq_dumpQ( ieutThreadData_t *pThreadData
 //Check whether any messages can be delivered
 int32_t ieiq_checkWaiters( ieutThreadData_t *pThreadData
                          , ismEngine_Queue_t *q
-                         , ismEngine_AsyncData_t *asyncInfo);
+                         , ismEngine_AsyncData_t * asyncInfo
+                         , ismEngine_DelivererContext_t *delivererContext);
 
 // Return definition store handle
 ismStore_Handle_t ieiq_getDefnHdl( ismQHandle_t Qhdl );

--- a/server_engine/src/messageDelivery.c
+++ b/server_engine/src/messageDelivery.c
@@ -43,7 +43,8 @@ bool ism_engine_deliverMessage(ieutThreadData_t *pThreadData,
                                ismEngine_Message_t *pMessage,
                                ismMessageHeader_t *pMsgHdr,
                                ismMessageState_t messageState,
-                               uint32_t deliveryId)
+                               uint32_t deliveryId,
+                               ismEngine_DelivererContext_t * delivererContext)
 {
     bool reenableWaiter = true;
     ismEngine_DeliveryHandle_t hDeliveryHandle;
@@ -126,7 +127,8 @@ bool ism_engine_deliverMessage(ieutThreadData_t *pThreadData,
                                                    pMessage->AreaTypes,
                                                    pMessage->AreaLengths,
                                                    pMessage->pAreaData,
-                                                   pConsumer->pMsgCallbackContext);
+                                                   pConsumer->pMsgCallbackContext,
+                                                   delivererContext);
     }
     ieutTRACEL(pThreadData, reenableWaiter, ENGINE_CEI_TRACE,
                FUNCTION_EXIT "reenableWaiter='%s'\n", __func__,

--- a/server_engine/src/messageDelivery.h
+++ b/server_engine/src/messageDelivery.h
@@ -40,7 +40,8 @@ bool ism_engine_deliverMessage(ieutThreadData_t *pThreadData,
                                ismEngine_Message_t *pMessage,
                                ismMessageHeader_t *pMsgHdr,
                                ismMessageState_t messageState,
-                               uint32_t deliveryId);
+                               uint32_t deliveryId,
+                               ismEngine_DelivererContext_t * delivererContext );
 
 // Callback from destination when delivery status changes, such as
 // an empty destination or disabling a waiter

--- a/server_engine/src/multiConsumerQ.c
+++ b/server_engine/src/multiConsumerQ.c
@@ -1979,7 +1979,7 @@ mod_exit:
 
         // We don't care about any error encountered while attempting
         // to deliver a message to a waiter.
-        (void) iemq_checkWaiters(pThreadData, (ismQHandle_t) Q, NULL, NULL);
+        (void) iemq_checkWaiters(pThreadData, (ismQHandle_t) Q, NULL, delivererContext);
     }
 
 #if TRACETIMESTAMP_PUTMESSAGE

--- a/server_engine/src/multiConsumerQ.h
+++ b/server_engine/src/multiConsumerQ.h
@@ -57,7 +57,8 @@ int32_t iemq_putMessage(ieutThreadData_t *pThreadData,
                         ieqPutOptions_t putOptions,
                         ismEngine_Transaction_t *pTran,
                         ismEngine_Message_t *pMessage,
-                        ieqMsgInputType_t inputMsgTreatment);
+                        ieqMsgInputType_t inputMsgTreatment,
+                        ismEngine_DelivererContext_t * unused);
 // Completes the rehydrate of a queue
 int32_t iemq_completeRehydrate( ieutThreadData_t *pThreadData,
                                 ismQHandle_t Qhdl );
@@ -149,7 +150,8 @@ int32_t iemq_checkAvailableMsgs(ismQHandle_t Qhdl, ismEngine_Consumer_t *pConsum
 // see whether there are available messages for a queue
 int32_t iemq_checkWaiters( ieutThreadData_t *pThreadData
                          , ismQHandle_t Qhdl
-                         , ismEngine_AsyncData_t *asyncInfo);
+                         , ismEngine_AsyncData_t *asyncInfo
+                         , ismEngine_DelivererContext_t *delivererContext);
 
 
 // Queue Debug

--- a/server_engine/src/queueCommon.h
+++ b/server_engine/src/queueCommon.h
@@ -226,8 +226,11 @@ typedef int32_t (*ieqCheckAvailableMsgs_t)(ismQHandle_t, ismEngine_Consumer_t *)
 ///  @param[in] ismEngine_Message_t - message to put
 ///  @param[in] ieqMsgInputType_t   - IEQ_MSGTYPE_REFCOUNT (re-use & increment refcount)
 ///                                   or IEQ_MSGTYPE_INHERIT (re-use)
+///  @param[in] delivererContext    - Context from the deliverer contains the lock strategy
+///                       allows locks to persist rather than being repeatedly released and retaken 
+///                       when putting messages onto the queue from within a loop
 ///  @return                        - OK on success or an ISMRC error code
-typedef int32_t (*ieqPut_t)(ieutThreadData_t *, ismQHandle_t, ieqPutOptions_t, ismEngine_Transaction_t *, ismEngine_Message_t *, ieqMsgInputType_t);
+typedef int32_t (*ieqPut_t)(ieutThreadData_t *, ismQHandle_t, ieqPutOptions_t, ismEngine_Transaction_t *, ismEngine_Message_t *, ieqMsgInputType_t, ismEngine_DelivererContext_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
 ///  @brief
@@ -271,8 +274,12 @@ typedef int32_t (*ieqTermWaiter_t)(ieutThreadData_t *, ismQHandle_t, ismEngine_C
 ///    Type of the common checkWaiters function
 ///  @param[in] ieutThreadData_t * - Thread Data structure
 ///  @param[in] ismQHandle_t       - Queue
+///  @param[in] asyncData          - Some async data
+///  @param[in] delivererContext   - Context from the deliverer contains the lock strategy
+///                       allows locks to persist rather than being repeatedly released and retaken
+///                       when putting messages onto the queue from within a loop
 ///  @return                       - OK on success or an ISMRC error code
-typedef int32_t (*ieqCheckWaiters_t)(ieutThreadData_t *, ismQHandle_t, ismEngine_AsyncData_t *);
+typedef int32_t (*ieqCheckWaiters_t)(ieutThreadData_t *, ismQHandle_t, ismEngine_AsyncData_t * ,ismEngine_DelivererContext_t *);
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -596,11 +603,11 @@ typedef struct ismEngine_Queue_t
 #define ieq_checkAvailableMsgs(qhdl, consumer) \
   ((ismEngine_Queue_t *)qhdl)->pInterface->checkAvailableMsgs(qhdl, consumer)
 ///Calls the correct checkWaiters function for the given queue
-#define ieq_checkWaiters(thrd,qhdl,asyncdata) \
-  ((ismEngine_Queue_t *)qhdl)->pInterface->checkWaiters(thrd, qhdl,asyncdata)
+#define ieq_checkWaiters(thrd,qhdl,asyncdata,delivererContext) \
+  ((ismEngine_Queue_t *)qhdl)->pInterface->checkWaiters(thrd, qhdl,asyncdata,delivererContext)
 /// Macro used to invoke the appropriate put function for the supplied Queue Handle
-#define ieq_put(thrd, qhdl, options, tran, msg, mtype) \
-  ((ismEngine_Queue_t *)qhdl)->pInterface->put(thrd, qhdl, options, tran, msg, mtype)
+#define ieq_put(thrd, qhdl, options, tran, msg, mtype, context) \
+  ((ismEngine_Queue_t *)qhdl)->pInterface->put(thrd, qhdl, options, tran, msg, mtype, context)
 /// Macro used to invoke the appropriate rehydrate function for the supplied Queue Handle
 #define ieq_rehydrateMsg(thrd, qhdl, msg, tran, hdl, ref) \
   ((ismEngine_Queue_t *)qhdl)->pInterface->rehydrateMsg(thrd, qhdl, msg, tran, hdl, ref)

--- a/server_engine/src/queueCommon.h
+++ b/server_engine/src/queueCommon.h
@@ -229,6 +229,14 @@ typedef int32_t (*ieqCheckAvailableMsgs_t)(ismQHandle_t, ismEngine_Consumer_t *)
 ///  @param[in] delivererContext    - Context from the deliverer contains the lock strategy
 ///                       allows locks to persist rather than being repeatedly released and retaken 
 ///                       when putting messages onto the queue from within a loop
+///
+/// The delivererContext is not guarenteed to be passed all the way to delivery.
+/// It is to hold state for cases where multiple messages are processed as a
+/// batch in a loop where actions within the loop could cause performance
+/// problems if knowledge is not passed itterations of the loop.
+/// The context is not placed on the queue with the message and any asynchronous paths will
+/// not contain it.
+///
 ///  @return                        - OK on success or an ISMRC error code
 typedef int32_t (*ieqPut_t)(ieutThreadData_t *, ismQHandle_t, ieqPutOptions_t, ismEngine_Transaction_t *, ismEngine_Message_t *, ieqMsgInputType_t, ismEngine_DelivererContext_t *);
 

--- a/server_engine/src/remoteServers.c
+++ b/server_engine/src/remoteServers.c
@@ -359,8 +359,8 @@ static inline int32_t iers_putAllRetained(ieutThreadData_t *pThreadData,
                                  ieqPutOptions_NONE, // RETAINED?
                                  pTran,
                                  pMessage,
-                                 IEQ_MSGTYPE_INHERIT,
-                                 NULL ); // already incremented
+                                 IEQ_MSGTYPE_INHERIT, // already incremented
+                                 NULL );
 
                     if (rc != OK) break;
                 }

--- a/server_engine/src/remoteServers.c
+++ b/server_engine/src/remoteServers.c
@@ -359,7 +359,8 @@ static inline int32_t iers_putAllRetained(ieutThreadData_t *pThreadData,
                                  ieqPutOptions_NONE, // RETAINED?
                                  pTran,
                                  pMessage,
-                                 IEQ_MSGTYPE_INHERIT); // already incremented
+                                 IEQ_MSGTYPE_INHERIT,
+                                 NULL ); // already incremented
 
                     if (rc != OK) break;
                 }

--- a/server_engine/src/simpQ.c
+++ b/server_engine/src/simpQ.c
@@ -940,7 +940,7 @@ int32_t iesq_putMessage( ieutThreadData_t *pThreadData
     }
 
     //And try and deliver any messages
-    rc = iesq_checkWaiters(pThreadData, (ismQHandle_t)Q, NULL, NULL);
+    rc = iesq_checkWaiters(pThreadData, (ismQHandle_t)Q, NULL, delivererContext);
 
     //If we've hit maximum do a quick check for expired messages
     if (Q->bufferedMsgs >= pPolicyInfo->maxMessageCount)
@@ -2761,7 +2761,7 @@ static int32_t iesq_putToWaitingGetter( ieutThreadData_t *pThreadData
             // The only valid return codes from this function is OK
             // or ISMRC_NoAvailWaiter. If checkWaiters encounters a
             // problem we do not care.
-            (void) iesq_checkWaiters(pThreadData, (ismQHandle_t)q, NULL, NULL);
+            (void) iesq_checkWaiters(pThreadData, (ismQHandle_t)q, NULL, delivererContext);
         }
     }
     else

--- a/server_engine/src/simpQ.c
+++ b/server_engine/src/simpQ.c
@@ -47,7 +47,8 @@
 static int32_t iesq_putToWaitingGetter( ieutThreadData_t *pThreadData
                                       , iesqQueue_t *q
                                       , ismEngine_Message_t *msg 
-                                      , uint8_t msgFlags );
+                                      , uint8_t msgFlags
+                                      , ismEngine_DelivererContext_t * delivererContext );
 static int32_t iesq_getMessage( ieutThreadData_t *pThreadData
                               , iesqQueue_t *Q
                               , ismEngine_Message_t **outmsg
@@ -673,7 +674,8 @@ int32_t iesq_putMessage( ieutThreadData_t *pThreadData
                        , ieqPutOptions_t putOptions
                        , ismEngine_Transaction_t *pTran
                        , ismEngine_Message_t *inmsg
-                       , ieqMsgInputType_t inputMsgTreatment)
+                       , ieqMsgInputType_t inputMsgTreatment
+                       , ismEngine_DelivererContext_t * delivererContext )
 {
     int32_t rc = 0;
     iesqQueue_t *Q = (iesqQueue_t *)Qhdl;
@@ -826,7 +828,7 @@ int32_t iesq_putMessage( ieutThreadData_t *pThreadData
     //and intermediateQ it is useful to be able to switch it off.
     if (Q->bufferedMsgs == 0)
     {
-        rc = iesq_putToWaitingGetter(pThreadData, Q, qmsg, msgFlags);
+        rc = iesq_putToWaitingGetter(pThreadData, Q, qmsg, msgFlags, delivererContext);
         if (rc == OK)
         {
             //We've given the message to someone..we're done
@@ -938,7 +940,7 @@ int32_t iesq_putMessage( ieutThreadData_t *pThreadData
     }
 
     //And try and deliver any messages
-    rc = iesq_checkWaiters(pThreadData, (ismQHandle_t)Q, NULL);
+    rc = iesq_checkWaiters(pThreadData, (ismQHandle_t)Q, NULL, NULL);
 
     //If we've hit maximum do a quick check for expired messages
     if (Q->bufferedMsgs >= pPolicyInfo->maxMessageCount)
@@ -993,7 +995,8 @@ int32_t iesq_importMessage( ieutThreadData_t *pThreadData
                                 , ieqPutOptions_NONE
                                 , NULL
                                 , pMessage
-                                , IEQ_MSGTYPE_INHERIT);
+                                , IEQ_MSGTYPE_INHERIT
+                                , NULL );
 
     return rc;
 }
@@ -1532,7 +1535,8 @@ void iesq_SLEReplayPut( ietrReplayPhase_t Phase
                                          , pSLE->putOptions
                                          , NULL
                                          , pSLE->pMsg
-                                         , IEQ_MSGTYPE_INHERIT ))
+                                         , IEQ_MSGTYPE_INHERIT 
+                                         , NULL ))
                 {
                     // If we failed, we need to decrement the message usage count which was
                     // incremented during the original put.
@@ -1767,7 +1771,7 @@ void iesq_dumpQ( ieutThreadData_t *pThreadData
                                               IEQ_COMPLETEWAITERACTION_OPT_NODELIVER,
                                               (previousState == IEWS_WAITERSTATUS_ENABLED));
                 }
-                (void)iesq_checkWaiters(pThreadData, Qhdl, NULL);
+                (void)iesq_checkWaiters(pThreadData, Qhdl, NULL, NULL);
             }
             else
             {
@@ -2480,7 +2484,8 @@ static int32_t iesq_getMessage( ieutThreadData_t *pThreadData
 ///////////////////////////////////////////////////////////////////////////////
 int32_t iesq_checkWaiters( ieutThreadData_t *pThreadData
                          , ismQHandle_t Qhdl
-                         , ismEngine_AsyncData_t *asyncInfo)
+                         , ismEngine_AsyncData_t *asyncInfo
+                         , ismEngine_DelivererContext_t * delivererContext)
 {
     int32_t rc = OK;
     bool loopAgain = true;
@@ -2543,7 +2548,8 @@ int32_t iesq_checkWaiters( ieutThreadData_t *pThreadData
                                     msg,
                                     &msgHdr,
                                     ismMESSAGE_STATE_CONSUMED,
-                                    0);
+                                    0,
+                                    delivererContext);
 
                 if (reenableWaiter)
                 {
@@ -2657,7 +2663,8 @@ static inline uint32_t iesq_choosePageSize( void )
 static int32_t iesq_putToWaitingGetter( ieutThreadData_t *pThreadData
                                       , iesqQueue_t *q
                                       , ismEngine_Message_t *msg
-                                      , uint8_t msgFlags )
+                                      , uint8_t msgFlags 
+                                      , ismEngine_DelivererContext_t * delivererContext)
 {
     int32_t rc = OK;
     bool deliveredMessage = false;
@@ -2695,7 +2702,8 @@ static int32_t iesq_putToWaitingGetter( ieutThreadData_t *pThreadData
                     , msg
                     , &msgHdr
                     , ismMESSAGE_STATE_CONSUMED
-                    , 0 );
+                    , 0
+                    , delivererContext );
 
             if (reenableWaiter)
             {
@@ -2753,7 +2761,7 @@ static int32_t iesq_putToWaitingGetter( ieutThreadData_t *pThreadData
             // The only valid return codes from this function is OK
             // or ISMRC_NoAvailWaiter. If checkWaiters encounters a
             // problem we do not care.
-            (void) iesq_checkWaiters(pThreadData, (ismQHandle_t)q, NULL);
+            (void) iesq_checkWaiters(pThreadData, (ismQHandle_t)q, NULL, NULL);
         }
     }
     else

--- a/server_engine/src/simpQ.h
+++ b/server_engine/src/simpQ.h
@@ -38,7 +38,8 @@ int32_t iesq_putMessage(ieutThreadData_t *pThreadData,
                         ieqPutOptions_t putOptions,
                         ismEngine_Transaction_t *pTran,
                         ismEngine_Message_t *pMessage,
-                        ieqMsgInputType_t inputMsgTreatment);
+                        ieqMsgInputType_t inputMsgTreatment,
+                        ismEngine_DelivererContext_t * unused);
 
 /* Used to import messages */
 int32_t iesq_importMessage( ieutThreadData_t *pThreadData
@@ -86,7 +87,8 @@ int32_t iesq_checkAvailableMsgs(ismQHandle_t Qhdl, ismEngine_Consumer_t *pConsum
 
 int32_t iesq_checkWaiters( ieutThreadData_t *pThreadData
                          , ismQHandle_t Qhdl
-                         , ismEngine_AsyncData_t *asyncInfo);
+                         , ismEngine_AsyncData_t * asyncInfo
+                         , ismEngine_DelivererContext_t * delivererContext);
 
 
 int32_t iesq_drainQ(ieutThreadData_t *pThreadData, ismQHandle_t Qhdl);

--- a/server_engine/src/topicTreeRetained.c
+++ b/server_engine/src/topicTreeRetained.c
@@ -306,8 +306,8 @@ int32_t iett_putRetainedMessagesToSubscription(ieutThreadData_t *pThreadData,
                              ieqPutOptions_RETAINED,
                              pTran,
                              pMessage,
-                             IEQ_MSGTYPE_INHERIT,
-                             NULL ); // already incremented
+                             IEQ_MSGTYPE_INHERIT, // already incremented
+                             NULL );
 
                 // Release the remaining messages if there was an error
                 if (rc != OK)

--- a/server_engine/src/topicTreeRetained.c
+++ b/server_engine/src/topicTreeRetained.c
@@ -269,7 +269,8 @@ int32_t iett_putRetainedMessagesToSubscription(ieutThreadData_t *pThreadData,
                                                                pMessage->pAreaData,
                                                                NULL,
                                                                selectionRule,
-                                                               selectionRuleLen);
+                                                               selectionRuleLen,
+                                                               NULL);
             }
             else
             {
@@ -305,7 +306,8 @@ int32_t iett_putRetainedMessagesToSubscription(ieutThreadData_t *pThreadData,
                              ieqPutOptions_RETAINED,
                              pTran,
                              pMessage,
-                             IEQ_MSGTYPE_INHERIT); // already incremented
+                             IEQ_MSGTYPE_INHERIT,
+                             NULL ); // already incremented
 
                 // Release the remaining messages if there was an error
                 if (rc != OK)
@@ -534,7 +536,8 @@ int32_t iett_putRetainedMessageToNewSubs(ieutThreadData_t *pThreadData,
                                                                        message->pAreaData,
                                                                        topicString,
                                                                        selectionRule,
-                                                                       selectionRuleLen );
+                                                                       selectionRuleLen,
+                                                                       NULL );
 
                         if (cacheThisSelectionResult == true) cachedSubPolicySelectionResult = selResult;
                     }
@@ -572,7 +575,8 @@ int32_t iett_putRetainedMessageToNewSubs(ieutThreadData_t *pThreadData,
                                                  ieqPutOptions_NONE,
                                                  NULL, // no transaction
                                                  message,
-                                                 IEQ_MSGTYPE_REFCOUNT);
+                                                 IEQ_MSGTYPE_REFCOUNT,
+                                                 NULL );
 
                         if (msg_rc != OK)
                         {
@@ -2662,7 +2666,8 @@ XAPI int32_t WARN_CHECKRC ism_engine_getRetainedMessage(
                                                   pMessage->AreaTypes,
                                                   pMessage->AreaLengths,
                                                   pMessage->pAreaData,
-                                                  pMessageContext);
+                                                  pMessageContext,
+                                                  NULL);
 
             if (keepRunning == false)
             {

--- a/server_engine/src/waiterStatus.c
+++ b/server_engine/src/waiterStatus.c
@@ -171,7 +171,7 @@ int32_t ieq_enableWaiter( ieutThreadData_t *pThreadData,
          && ((oldState == IEWS_WAITERSTATUS_DISABLED) ||
              (oldState & IEWS_WAITERSTATUSMASK_ACTIVE)))
     {
-        rc = ieq_checkWaiters(pThreadData, Qhdl, NULL);
+        rc = ieq_checkWaiters(pThreadData, Qhdl, NULL, NULL);
     }
 mod_exit:
     ieutTRACEL(pThreadData, rc,  ENGINE_FNC_TRACE, FUNCTION_EXIT "rc=%d old=%u\n", __func__, rc, (uint32_t)oldState);
@@ -717,7 +717,7 @@ void iews_unlockAfterQOperation( ieutThreadData_t *pThreadData
 
         //We locked it in delivering state and that promises to call checkWaiters
         //...honour the promise
-        ieq_checkWaiters(pThreadData, Q, NULL);
+        ieq_checkWaiters(pThreadData, Q, NULL, NULL);
     }
     else
     {
@@ -787,7 +787,7 @@ void ieq_completeWaiterActions(ieutThreadData_t *pThreadData,
                     //We've re-enabled a waiter that was in delivering: deliver any messages
                     if (allowDelivery)
                     {
-                        ieq_checkWaiters(pThreadData, Q, NULL);
+                        ieq_checkWaiters(pThreadData, Q, NULL, NULL);
                     }
                 }
                 else
@@ -865,7 +865,7 @@ void ieq_completeWaiterActions(ieutThreadData_t *pThreadData,
                         //We have enabled a waiter that was in *_PEND/DELIVERING
                         if (doneDisable && allowDelivery)
                         {
-                           ieq_checkWaiters(pThreadData, Q, NULL);
+                           ieq_checkWaiters(pThreadData, Q, NULL, NULL);
                         }
                     }
                     else

--- a/server_engine/test/1M_Client_test.c
+++ b/server_engine/test/1M_Client_test.c
@@ -58,7 +58,8 @@ bool asyncMessageCallback(ismEngine_ConsumerHandle_t      hConsumer,
                           ismMessageAreaType_t            areaTypes[areaCount],
                           size_t                          areaLengths[areaCount],
                           void *                          pAreaData[areaCount],
-                          void *                          pConsumerContext);
+                          void *                          pConsumerContext,
+                          ismEngine_DelivererContext_t *  _delivererContext );
 
 
 int main(int argc, char *argv[])
@@ -254,7 +255,8 @@ bool asyncMessageCallback(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext)
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext)
 {
     static int countIncomingMessage = 1;
     char *reportMsg = NULL;

--- a/server_engine/test/Car_HQ_TwoWayMsgs_multiThread.c
+++ b/server_engine/test/Car_HQ_TwoWayMsgs_multiThread.c
@@ -134,7 +134,8 @@ bool asyncHQ2CarMessageCallback(
         ismMessageAreaType_t areaTypes[areaCount],
         size_t areaLengths[areaCount],
         void * pAreaData[areaCount],
-        void * pConsumerContext)
+        void * pConsumerContext,
+        ismEngine_DelivererContext_t * unused)
 {
     int32_t rc = OK;
     char *temp_msg = (char *)pAreaData[1];
@@ -477,7 +478,8 @@ bool asyncMessageCallback(
         ismMessageAreaType_t areaTypes[areaCount],
         size_t areaLengths[areaCount],
         void * pAreaData[areaCount],
-        void * pConsumerContext)
+        void * pConsumerContext,
+        ismEngine_DelivererContext_t * unused )
 {
     int32_t rc = OK;
     msgDetails_t *temp_msg = pAreaData[0];

--- a/server_engine/test/Cars_HQ_multiThreads.c
+++ b/server_engine/test/Cars_HQ_multiThreads.c
@@ -388,7 +388,8 @@ bool asyncMessageCallback(
         ismMessageAreaType_t areaTypes[areaCount],
         size_t areaLengths[areaCount],
         void * pAreaData[areaCount],
-        void * pConsumerContext);
+        void * pConsumerContext,
+        ismEngine_DelivererContext_t * _delivererContext);
 
 void durableHQSubsCB(
         ismEngine_SubscriptionHandle_t subHandle,
@@ -785,7 +786,8 @@ bool asyncMessageCallback(
         ismMessageAreaType_t areaTypes[areaCount],
         size_t areaLengths[areaCount],
         void * pAreaData[areaCount],
-        void * pConsumerContext)
+        void * pConsumerContext,
+        ismEngine_DelivererContext_t * _delivererContext)
 {
     int32_t rc = OK;
     msgDetails_t *temp_msg = pAreaData[0];

--- a/server_engine/test/multi_prod_node_msg.c
+++ b/server_engine/test/multi_prod_node_msg.c
@@ -72,7 +72,8 @@ bool asyncMessageCallback(
 						  ismMessageAreaType_t            areaTypes[areaCount],
 						  size_t                          areaLengths[areaCount],
 						  void *                          pAreaData[areaCount],
-						  void *                          pConsumerContext);
+						  void *                          pConsumerContext,
+                                                  ismEngine_DelivererContext_t *  _delivererContext);
 
 
 int main(int argc, char *argv[])
@@ -280,7 +281,8 @@ bool asyncMessageCallback(
 		ismMessageAreaType_t            areaTypes[areaCount],
 		size_t                          areaLengths[areaCount],
 		void *                          pAreaData[areaCount],
-		void *                          pConsumerContext)
+		void *                          pConsumerContext,
+                ismEngine_DelivererContext_t *  _delivererContext)
 {
     static int countIncomingMessage = 1;
 	static int i=1;

--- a/server_engine/test/multi_thread_QoS1.c
+++ b/server_engine/test/multi_thread_QoS1.c
@@ -96,7 +96,8 @@ bool asyncMessageCallback(
         ismMessageAreaType_t areaTypes[areaCount],
         size_t areaLengths[areaCount],
         void * pAreaData[areaCount],
-        void * pConsumerContext);
+        void * pConsumerContext,
+        ismEngine_DelivererContext_t * _delivererContext);
 
 void *create_put_messages(void *arg)
 {
@@ -302,7 +303,8 @@ bool asyncMessageCallback(ismEngine_ConsumerHandle_t hConsumer,
                           ismMessageAreaType_t areaTypes[areaCount],
                           size_t areaLengths[areaCount],
                           void * pAreaData[areaCount],
-                          void * pConsumerContext)
+                          void * pConsumerContext,
+                          ismEngine_DelivererContext_t * _delivererContext)
 {
     static int countIncomingMessage = 1;
     int32_t threadNo, msgNo;

--- a/server_engine/test/simple_thread_test.c
+++ b/server_engine/test/simple_thread_test.c
@@ -91,7 +91,7 @@ bool asyncMessageCallback(ismEngine_ConsumerHandle_t hConsumer,
         ismMessageHeader_t * pMsgDetails, uint8_t areaCount,
         ismMessageAreaType_t areaTypes[areaCount],
         size_t areaLengths[areaCount], void * pAreaData[areaCount],
-        void * pConsumerContext);
+        void * pConsumerContext, ismEngine_DelivererContext_t * _delivererContext);
 
 void *create_put_messages(void *arg)
 {
@@ -298,7 +298,8 @@ bool asyncMessageCallback(ismEngine_ConsumerHandle_t hConsumer,
                           ismMessageAreaType_t areaTypes[areaCount],
                           size_t areaLengths[areaCount],
                           void * pAreaData[areaCount],
-                          void * pConsumerContext)
+                          void * pConsumerContext,
+                          ismEngine_DelivererContext_t * _delivererContext)
 {
     static int countIncomingMessage = 1;
 

--- a/server_engine/test/testBadFillSubs.c
+++ b/server_engine/test/testBadFillSubs.c
@@ -201,7 +201,8 @@ bool test_msgCallback(ismEngine_ConsumerHandle_t      hConsumer,
                       ismMessageAreaType_t            areaTypes[areaCount],
                       size_t                          areaLengths[areaCount],
                       void *                          pAreaData[areaCount],
-                      void *                          pContext)
+                      void *                          pContext,
+                      ismEngine_DelivererContext_t *  _delivererContext)
 {
     msgCallbackContext_t *context = *((msgCallbackContext_t **)pContext);
 

--- a/server_engine/test/testClientStateRecovery.c
+++ b/server_engine/test/testClientStateRecovery.c
@@ -175,7 +175,8 @@ bool messageDeliveryPreRestartCB(
         ismMessageAreaType_t            areaTypes[areaCount],
         size_t                          areaLengths[areaCount],
         void *                          pAreaData[areaCount],
-        void *                          pConsumerContext)
+        void *                          pConsumerContext,
+        ismEngine_DelivererContext_t *  _delivererContext)
 {
     verbose(2, "Message order id %lu delivered, delivery id %lu. \"%s\".",
             pMsgDetails->OrderId, deliveryId, pAreaData[1]);
@@ -205,7 +206,8 @@ bool messageDeliveryCB(
         ismMessageAreaType_t            areaTypes[areaCount],
         size_t                          areaLengths[areaCount],
         void *                          pAreaData[areaCount],
-        void *                          pConsumerContext)
+        void *                          pConsumerContext,
+        ismEngine_DelivererContext_t *  _delivererContext)
 {
     verbose(2, "Message order id %lu delivered, delivery id %lu. \"%s\".",
             pMsgDetails->OrderId, deliveryId, pAreaData[1]);

--- a/server_engine/test/testConsumer.c
+++ b/server_engine/test/testConsumer.c
@@ -96,7 +96,8 @@ bool ConsumerCallback( ismEngine_ConsumerHandle_t hConsumer
                      , ismMessageAreaType_t       areaTypes[areaCount]
                      , size_t                     areaLengths[areaCount]
                      , void *                     pAreaData[areaCount]
-                     , void *                     pConsumerContext);
+                     , void *                     pConsumerContext
+                     , ismEngine_DelivererContext_t * _delivererContext );
 void *ProducerThread(void *arg);
 int ProcessArgs( int argc
                , char **argv
@@ -534,7 +535,8 @@ bool ConsumerCallback( ismEngine_ConsumerHandle_t hConsumer
                      , ismMessageAreaType_t       areaTypes[areaCount]
                      , size_t                     areaLengths[areaCount]
                      , void *                     pAreaData[areaCount]
-                     , void *                     pConsumerContext)
+                     , void *                     pConsumerContext
+                     , ismEngine_DelivererContext_t * _delivererContext )
 {
     uint32_t rc;
     Consumer_t *pConsumer = *(Consumer_t **)pConsumerContext;

--- a/server_engine/test/testFillSubs.c
+++ b/server_engine/test/testFillSubs.c
@@ -399,7 +399,8 @@ bool test_msgCallback(ismEngine_ConsumerHandle_t      hConsumer,
                       ismMessageAreaType_t            areaTypes[areaCount],
                       size_t                          areaLengths[areaCount],
                       void *                          pAreaData[areaCount],
-                      void *                          pContext)
+                      void *                          pContext,
+                      ismEngine_DelivererContext_t *  _delivererContext )
 {
     msgCallbackContext_t *context = *((msgCallbackContext_t **)pContext);
 

--- a/server_engine/test/testLateOwner.c
+++ b/server_engine/test/testLateOwner.c
@@ -83,7 +83,8 @@ bool retainedDeliveryCallback(ismEngine_ConsumerHandle_t      hConsumer,
                               ismMessageAreaType_t            areaTypes[areaCount],
                               size_t                          areaLengths[areaCount],
                               void *                          pAreaData[areaCount],
-                              void *                          pContext)
+                              void *                          pContext,
+                              ismEngine_DelivererContext_t *  _delivererContext )
 {
     retainedCbContext_t *context = *((retainedCbContext_t **)pContext);
 

--- a/server_engine/test/testMixedRestart.c
+++ b/server_engine/test/testMixedRestart.c
@@ -334,7 +334,8 @@ bool noAckCallback(
         ismMessageAreaType_t            areaTypes[areaCount],
         size_t                          areaLengths[areaCount],
         void *                          pAreaData[areaCount],
-        void *                          pConsumerContext)
+        void *                          pConsumerContext,
+        ismEngine_DelivererContext_t *  _delivererContext )
 {
     ism_engine_releaseMessage(hMessage);
     return true; //We'd like more messages
@@ -576,11 +577,12 @@ void createGenerations(uint32_t numGens)
 		TEST_ASSERT(rc == OK, ("%d != %d", rc, OK));
 
 		rc = ieq_put( pThreadData
-		        , hQueue
-				, ieqPutOptions_NONE
-				, NULL
-				, hBigMsg
-				, IEQ_MSGTYPE_INHERIT );
+                              , hQueue
+                              , ieqPutOptions_NONE
+                              , NULL
+                              , hBigMsg
+                              , IEQ_MSGTYPE_INHERIT
+                              , NULL );
 
 		//We're going to look at hBigMsg - in a real appliance it could have been got and freed
 		//by now but we know there is no consumer
@@ -677,7 +679,8 @@ bool messageArrivedCallback(
         ismMessageAreaType_t            areaTypes[areaCount],
         size_t                          areaLengths[areaCount],
         void *                          pAreaData[areaCount],
-        void *                          pConsumerContext)
+        void *                          pConsumerContext,
+        ismEngine_DelivererContext_t *  _delivererContext )
 {
     subsContext_t *ctxt = *((subsContext_t **)pConsumerContext);
 

--- a/server_engine/test/testMoreLateThings.c
+++ b/server_engine/test/testMoreLateThings.c
@@ -84,7 +84,8 @@ bool lateMessageDeliveryCallback(ismEngine_ConsumerHandle_t      hConsumer,
                                  ismMessageAreaType_t            areaTypes[areaCount],
                                  size_t                          areaLengths[areaCount],
                                  void *                          pAreaData[areaCount],
-                                 void *                          pContext)
+                                 void *                          pContext,
+                                 ismEngine_DelivererContext_t *  _delivererContext )
 {
     int64_t payLoadAreaNum = -1;
     bool wantMoreMsgs = true;
@@ -168,7 +169,8 @@ int32_t createLateMessage(void)
                     , ieqPutOptions_SET_ORDERID
                     , NULL
                     , hBigMsg
-                    , IEQ_MSGTYPE_INHERIT );
+                    , IEQ_MSGTYPE_INHERIT
+                    , NULL );
 
         //We're going to look at hBigMsg - in a real appliance it could have been got and freed
         //by now but we know there is no consumer
@@ -211,7 +213,8 @@ int32_t createLateMessage(void)
                 , ieqPutOptions_SET_ORDERID
                 , NULL
                 , hLateMsg
-                , IEQ_MSGTYPE_INHERIT );
+                , IEQ_MSGTYPE_INHERIT 
+                , NULL );
 
     //Now restart and verify we get the messages we expect
 
@@ -305,7 +308,8 @@ static bool PrepareLateCallback(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext)
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext )
 {
     testPreparedLateGetCallbackContext_t **ppCallbackContext = (testPreparedLateGetCallbackContext_t **)pConsumerContext;
     testPreparedLateGetCallbackContext_t *pCallbackContext = *ppCallbackContext;
@@ -444,7 +448,8 @@ int32_t createPreparedLateGet(void)
                     , ieqPutOptions_NONE
                     , NULL
                     , hBigMsg
-                    , IEQ_MSGTYPE_INHERIT );
+                    , IEQ_MSGTYPE_INHERIT
+                    , NULL );
 
         //We're going to look at hBigMsg - in a real appliance it could have been got and freed
         //by now but we know there is no consumer
@@ -562,7 +567,8 @@ static bool CheckNotGotMsgCallback(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext)
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext )
 {
     testPreparedLateGetCallbackContext_t **ppCallbackContext = (testPreparedLateGetCallbackContext_t **)pConsumerContext;
     testPreparedLateGetCallbackContext_t *pCallbackContext = *ppCallbackContext;

--- a/server_engine/test/testPubSubRestart.c
+++ b/server_engine/test/testPubSubRestart.c
@@ -288,7 +288,8 @@ bool messageArrivedCallback(
         ismMessageAreaType_t            areaTypes[areaCount],
         size_t                          areaLengths[areaCount],
         void *                          pAreaData[areaCount],
-        void *                          pConsumerContext)
+        void *                          pConsumerContext,
+        ismEngine_DelivererContext_t *  _delivererContext)
 {
     subscriberStateComplete_t *subState = *(subscriberStateComplete_t **)pConsumerContext;
     uint64_t *pCallbacksInProgress = &(CallbacksInProgress);

--- a/server_engine/test/testPubSubThreads.c
+++ b/server_engine/test/testPubSubThreads.c
@@ -99,7 +99,8 @@ bool SubberGotMessageCallback(
         ismMessageAreaType_t            areaTypes[areaCount],
         size_t                          areaLengths[areaCount],
         void *                          pAreaData[areaCount],
-        void *                          pConsumerContext);
+        void *                          pConsumerContext,
+        ismEngine_DelivererContext_t *  _delivererContext);
 
 bool BgSubberGotMessageCallback(
         ismEngine_ConsumerHandle_t      hConsumer,
@@ -113,7 +114,8 @@ bool BgSubberGotMessageCallback(
         ismMessageAreaType_t            areaTypes[areaCount],
         size_t                          areaLengths[areaCount],
         void *                          pAreaData[areaCount],
-        void *                          pConsumerContext);
+        void *                          pConsumerContext,
+        ismEngine_DelivererContext_t *  _delivererContext);
 
 /*
  * Get the number of CPU threads available
@@ -1709,7 +1711,8 @@ bool SubberGotMessageCallback(
         ismMessageAreaType_t            areaTypes[areaCount],
         size_t                          areaLengths[areaCount],
         void *                          pAreaData[areaCount],
-        void *                          pConsumerContext)
+        void *                          pConsumerContext,
+        ismEngine_DelivererContext_t *  _delivererContext)
 {
     callbackContext *ctxt = *((callbackContext **)pConsumerContext);
 
@@ -1770,7 +1773,8 @@ bool BgSubberGotMessageCallback(
         ismMessageAreaType_t            areaTypes[areaCount],
         size_t                          areaLengths[areaCount],
         void *                          pAreaData[areaCount],
-        void *                          pConsumerContext)
+        void *                          pConsumerContext,
+        ismEngine_DelivererContext_t *  _delivererContext )
 {
     callbackContext *ctxt = *((callbackContext **)pConsumerContext);
 

--- a/server_engine/test/testQueueMonitor.c
+++ b/server_engine/test/testQueueMonitor.c
@@ -85,7 +85,8 @@ bool ConsumerCallback( ismEngine_ConsumerHandle_t hConsumer
                      , ismMessageAreaType_t       areaTypes[areaCount]
                      , size_t                     areaLengths[areaCount]
                      , void *                     pAreaData[areaCount]
-                     , void *                     pConsumerContext);
+                     , void *                     pConsumerContext
+                     , ismEngine_DelivererContext_t * _delivererContext );
 
 void backgroundProducer(void *context);
 
@@ -439,7 +440,8 @@ bool ConsumerCallback( ismEngine_ConsumerHandle_t hConsumer
                      , ismMessageAreaType_t       areaTypes[areaCount]
                      , size_t                     areaLengths[areaCount]
                      , void *                     pAreaData[areaCount]
-                     , void *                     pConsumerContext)
+                     , void *                     pConsumerContext
+                     , ismEngine_DelivererContext_t * _delivererContext)
 {
     uint32_t rc;
     uint32_t i;

--- a/server_engine/test/testRehydrateInflightMsgs.c
+++ b/server_engine/test/testRehydrateInflightMsgs.c
@@ -93,7 +93,8 @@ bool consumerCallback(ismEngine_ConsumerHandle_t      hConsumer,
                               ismMessageAreaType_t            areaTypes[areaCount],
                               size_t                          areaLengths[areaCount],
                               void *                          pAreaData[areaCount],
-                              void *                          pContext)
+                              void *                          pContext,
+                              ismEngine_DelivererContext_t *  _delivererContext )
 {
     consumerContext_t *context = *((consumerContext_t **)pContext);
     bool wantMoreMessages = true;

--- a/server_engine/test/testStoreEvents.c
+++ b/server_engine/test/testStoreEvents.c
@@ -66,7 +66,8 @@ bool ConsumerCallback( ismEngine_ConsumerHandle_t hConsumer
                      , ismMessageAreaType_t       areaTypes[areaCount]
                      , size_t                     areaLengths[areaCount]
                      , void *                     pAreaData[areaCount]
-                     , void *                     pConsumerContext);
+                     , void *                     pConsumerContext
+                     , ismEngine_DelivererContext_t * _delivererContext );
 
 /********************************************************************/
 /* Global data                                                      */
@@ -113,7 +114,8 @@ bool ConsumerCallback( ismEngine_ConsumerHandle_t hConsumer
                      , ismMessageAreaType_t       areaTypes[areaCount]
                      , size_t                     areaLengths[areaCount]
                      , void *                     pAreaData[areaCount]
-                     , void *                     pConsumerContext)
+                     , void *                     pConsumerContext
+                     , ismEngine_DelivererContext_t * _delivererContext )
 {
     ismEngine_SessionHandle_t hSession = (ismEngine_SessionHandle_t)pConsumerContext;
 

--- a/server_engine/test/testSubMonitor.c
+++ b/server_engine/test/testSubMonitor.c
@@ -106,7 +106,8 @@ bool ConsumerCallback( ismEngine_ConsumerHandle_t hConsumer
                      , ismMessageAreaType_t       areaTypes[areaCount]
                      , size_t                     areaLengths[areaCount]
                      , void *                     pAreaData[areaCount]
-                     , void *                     pConsumerContext);
+                     , void *                     pConsumerContext
+                     , ismEngine_DelivererContext_t * _delivererContext );
 
 void backgroundPublisher(void *context);
 void backgroundSubscriber(void *context);
@@ -696,7 +697,8 @@ bool ConsumerCallback( ismEngine_ConsumerHandle_t hConsumer
                      , ismMessageAreaType_t       areaTypes[areaCount]
                      , size_t                     areaLengths[areaCount]
                      , void *                     pAreaData[areaCount]
-                     , void *                     pConsumerContext)
+                     , void *                     pConsumerContext
+                     , ismEngine_DelivererContext_t * _delivererContext )
 {
     ism_engine_releaseMessage(hMessage);
 

--- a/server_engine/test/test_31356.c
+++ b/server_engine/test/test_31356.c
@@ -120,7 +120,8 @@ bool ConsumeNoAckExplicitSuspend(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext)
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext )
 {
     bool keepingGoing = true;
     ConsumerInfo_t *pConsumerInfo =*(ConsumerInfo_t **)pConsumerContext;

--- a/server_engine/test/test_PMR27280.499.000.c
+++ b/server_engine/test/test_PMR27280.499.000.c
@@ -44,7 +44,8 @@ bool msgDeliveryCB(ismEngine_ConsumerHandle_t      hConsumer,
                    ismMessageAreaType_t            areaTypes[areaCount],
                    size_t                          areaLengths[areaCount],
                    void *                          pAreaData[areaCount],
-                   void *                          pContext)
+                   void *                          pContext,
+                   ismEngine_DelivererContext_t *  _delivererContext )
 {
     msgDeliveryCBContext_t *context = *((msgDeliveryCBContext_t **)pContext);
 

--- a/server_engine/test/test_SessionWideMQTTFlowControl.c
+++ b/server_engine/test/test_SessionWideMQTTFlowControl.c
@@ -144,7 +144,8 @@ bool ConsumeDelayAck(
         ismMessageAreaType_t            areaTypes[areaCount],
         size_t                          areaLengths[areaCount],
         void *                          pAreaData[areaCount],
-        void *                          pConsumerContext)
+        void *                          pConsumerContext,
+        ismEngine_DelivererContext_t *  _delivererContext)
 {
     receiveMsgContext_t *context = *(receiveMsgContext_t **)pConsumerContext;
 

--- a/server_engine/test/test_awkwardQDelete.c
+++ b/server_engine/test/test_awkwardQDelete.c
@@ -142,7 +142,8 @@ bool ConsumeDeleteRollbackCB(
         ismMessageAreaType_t            areaTypes[areaCount],
         size_t                          areaLengths[areaCount],
         void *                          pAreaData[areaCount],
-        void *                          pConsumerContext)
+        void *                          pConsumerContext,
+        ismEngine_DelivererContext_t *  _delivererContext )
 {
     ismEngine_TransactionHandle_t hTran= *(ismEngine_TransactionHandle_t *)pConsumerContext;
 
@@ -244,7 +245,8 @@ bool StashHandleForLaterAckCB(
 		ismMessageAreaType_t            areaTypes[areaCount],
 		size_t                          areaLengths[areaCount],
 		void *                          pAreaData[areaCount],
-		void *                          pConsumerContext)
+		void *                          pConsumerContext,
+                ismEngine_DelivererContext_t *  _delivererContext )
 {
 	stashedAckData_t *pStashedAckData = *(stashedAckData_t **)pConsumerContext;
 
@@ -1283,7 +1285,8 @@ bool receivedMsgCallback(
         ismMessageAreaType_t            areaTypes[areaCount],
         size_t                          areaLengths[areaCount],
         void *                          pAreaData[areaCount],
-        void *                          pConsumerContext)
+        void *                          pConsumerContext,
+        ismEngine_DelivererContext_t *  _delivererContext )
 {
     bool moreMsgsWanted = false;
 
@@ -2017,7 +2020,8 @@ static bool MsgArrivedTestDestroyConsumer(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext)
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext )
 {
     TestDestroyConsumer_ThreadInfo_t *pDestroyerInfo = *(TestDestroyConsumer_ThreadInfo_t **)pConsumerContext;
     uint32_t *msgsReceived = pDestroyerInfo->MsgsReceived;

--- a/server_engine/test/test_batchAcks.c
+++ b/server_engine/test/test_batchAcks.c
@@ -53,7 +53,8 @@ static bool deliveryCallback(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext);
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext);
 
 
 /*
@@ -170,7 +171,8 @@ static bool deliveryCallback(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext)
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext )
 {
     bool moreMessagesPlease = true;
     callbackContext_t **ppCallbackContext = (callbackContext_t **)pConsumerContext;

--- a/server_engine/test/test_clientState.c
+++ b/server_engine/test/test_clientState.c
@@ -124,7 +124,8 @@ static bool deliveryCallbackStealClientState(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext);
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext);
 
 static void clientStateNoStealCallback(
     int32_t                         reason,
@@ -3773,7 +3774,8 @@ static bool deliveryCallbackStealClientState(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext)
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext )
 {
     callbackContext_t **ppCallbackContext = (callbackContext_t **)pConsumerContext;
     callbackContext_t *pCallbackContext = *ppCallbackContext;

--- a/server_engine/test/test_discardOldMsgs.c
+++ b/server_engine/test/test_discardOldMsgs.c
@@ -399,7 +399,8 @@ static bool MsgFlowConsumerFunction(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext)
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext)
 {
     consumerContext_t *pContext = *(consumerContext_t **)pConsumerContext;
 
@@ -1306,7 +1307,8 @@ static bool DiscardRetainedConsumerFunction(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext)
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext )
 {
     discardRetainedTestConsumerContext_t *pConsContext = *(discardRetainedTestConsumerContext_t **)pConsumerContext;
 

--- a/server_engine/test/test_disconnectedClientNotification.c
+++ b/server_engine/test/test_disconnectedClientNotification.c
@@ -584,7 +584,8 @@ bool test_msgCallback(ismEngine_ConsumerHandle_t      hConsumer,
                       ismMessageAreaType_t            areaTypes[areaCount],
                       size_t                          areaLengths[areaCount],
                       void *                          pAreaData[areaCount],
-                      void *                          pContext)
+                      void *                          pContext,
+                      ismEngine_DelivererContext_t *  _delivererContext )
 {
     msgCallbackContext_t *context = *((msgCallbackContext_t **)pContext);
 
@@ -1205,7 +1206,8 @@ bool test_msgNotificationCallback(ismEngine_ConsumerHandle_t      hConsumer,
                                   ismMessageAreaType_t            areaTypes[areaCount],
                                   size_t                          areaLengths[areaCount],
                                   void *                          pAreaData[areaCount],
-                                  void *                          pContext)
+                                  void *                          pContext,
+                                  ismEngine_DelivererContext_t *  _delivererContext )
 {
     msgNotificationCallbackContext_t *context = *((msgNotificationCallbackContext_t **)pContext);
 

--- a/server_engine/test/test_expiringGet.c
+++ b/server_engine/test/test_expiringGet.c
@@ -53,7 +53,8 @@ bool basicGetCB(
         ismMessageAreaType_t            areaTypes[areaCount],
         size_t                          areaLengths[areaCount],
         void *                          pAreaData[areaCount],
-        void *                          pConsumerContext)
+        void *                          pConsumerContext,
+        ismEngine_DelivererContext_t *  _delivererContext )
 {
     testBasicGetContext_t *pGetContext = *(testBasicGetContext_t **)pConsumerContext;
     uint32_t dlvySlot = __sync_fetch_and_add(&(pGetContext->numUnackedMsgs), 1);
@@ -536,7 +537,8 @@ bool HangUntilReadyGetCB(
         ismMessageAreaType_t            areaTypes[areaCount],
         size_t                          areaLengths[areaCount],
         void *                          pAreaData[areaCount],
-        void *                          pConsumerContext)
+        void *                          pConsumerContext,
+        ismEngine_DelivererContext_t *  _delivererContext )
 {
     testTimingWindowGetContext_t *pGetContext = *(testTimingWindowGetContext_t **)pConsumerContext;
 

--- a/server_engine/test/test_exportBufferedMsgs.c
+++ b/server_engine/test/test_exportBufferedMsgs.c
@@ -348,7 +348,8 @@ bool markRcvdMessagesCallback(
         ismMessageAreaType_t            areaTypes[areaCount],
         size_t                          areaLengths[areaCount],
         void *                          pAreaData[areaCount],
-        void *                          pConsumerContext)
+        void *                          pConsumerContext,
+        ismEngine_DelivererContext_t *  _delivererContext )
 {
     testMarkRcvdContext_t *context = *(testMarkRcvdContext_t **)pConsumerContext;
 
@@ -403,7 +404,8 @@ bool countMessagesCallback(
         ismMessageAreaType_t            areaTypes[areaCount],
         size_t                          areaLengths[areaCount],
         void *                          pAreaData[areaCount],
-        void *                          pConsumerContext)
+        void *                          pConsumerContext,
+        ismEngine_DelivererContext_t *  _delivererContext )
 {
     testGetMsgContext_t *context = *(testGetMsgContext_t **)pConsumerContext;
     bool doAck = false;

--- a/server_engine/test/test_failedAllocs.c
+++ b/server_engine/test/test_failedAllocs.c
@@ -1492,7 +1492,8 @@ bool deliveryErrorsMsgArrivedCB(
         ismMessageAreaType_t            areaTypes[areaCount],
         size_t                          areaLengths[areaCount],
         void *                          pAreaData[areaCount],
-        void *                          pConsumerContext)
+        void *                          pConsumerContext,
+        ismEngine_DelivererContext_t *  _delivererContext)
 {
     uint32_t *pMsgCount = *(uint32_t **)pConsumerContext;
     __sync_add_and_fetch(pMsgCount, 1);

--- a/server_engine/test/test_flow.c
+++ b/server_engine/test/test_flow.c
@@ -289,7 +289,8 @@ bool ConsumerCallback( ismEngine_ConsumerHandle_t hConsumer
                      , ismMessageAreaType_t       areaTypes[areaCount]
                      , size_t                     areaLengths[areaCount]
                      , void *                     pAreaData[areaCount]
-                     , void *                     pConsumerContext)
+                     , void *                     pConsumerContext
+                     , ismEngine_DelivererContext_t * _delivererContext )
 {
     int urc;
     Consumer_t *pConsumer = *(Consumer_t **)pConsumerContext;

--- a/server_engine/test/test_fullCleanPagesScan.c
+++ b/server_engine/test/test_fullCleanPagesScan.c
@@ -50,7 +50,8 @@ static bool getMessagesCallback(
         ismMessageAreaType_t            areaTypes[areaCount],
         size_t                          areaLengths[areaCount],
         void *                          pAreaData[areaCount],
-        void *                          pConsumerContext)
+        void *                          pConsumerContext,
+        ismEngine_DelivererContext_t *  _delivererContext )
 {
     consumerContext_t *context = *(consumerContext_t **)pConsumerContext;
 

--- a/server_engine/test/test_globalTran.c
+++ b/server_engine/test/test_globalTran.c
@@ -1261,7 +1261,8 @@ bool RollbackGetConsumer( ismEngine_ConsumerHandle_t      hConsumer
                         , ismMessageAreaType_t            areaTypes[areaCount]
                         , size_t                          areaLengths[areaCount]
                         , void *                          pAreaData[areaCount]
-                        , void *                          pConsumerContext)
+                        , void *                          pConsumerContext
+                        , ismEngine_DelivererContext_t *  _delivererContext )
 {
     int32_t rc;
     RollbackGetContext_t *pContext = *(RollbackGetContext_t **)pConsumerContext;

--- a/server_engine/test/test_namedQueues.c
+++ b/server_engine/test/test_namedQueues.c
@@ -274,7 +274,8 @@ bool queueMessagesCallback(ismEngine_ConsumerHandle_t      hConsumer,
                            ismMessageAreaType_t            areaTypes[areaCount],
                            size_t                          areaLengths[areaCount],
                            void *                          pAreaData[areaCount],
-                           void *                          pContext)
+                           void *                          pContext,
+                           ismEngine_DelivererContext_t *  _delivererContext)
 {
     queueMessagesCbContext_t *context = *((queueMessagesCbContext_t **)pContext);
 

--- a/server_engine/test/test_nonAcker.c
+++ b/server_engine/test/test_nonAcker.c
@@ -251,7 +251,8 @@ bool ConsumeCallback(
         ismMessageAreaType_t            areaTypes[areaCount],
         size_t                          areaLengths[areaCount],
         void *                          pAreaData[areaCount],
-        void *                          pConsumerContext)
+        void *                          pConsumerContext,
+        ismEngine_DelivererContext_t *  _delivererContext)
 {
     receiveMsgContext_t *context = *(receiveMsgContext_t **)pConsumerContext;
 

--- a/server_engine/test/test_policyInfo.c
+++ b/server_engine/test/test_policyInfo.c
@@ -91,7 +91,8 @@ bool authChecksMessagesCallback(ismEngine_ConsumerHandle_t      hConsumer,
                                 ismMessageAreaType_t            areaTypes[areaCount],
                                 size_t                          areaLengths[areaCount],
                                 void *                          pAreaData[areaCount],
-                                void *                          pContext)
+                                void *                          pContext,
+                                ismEngine_DelivererContext_t *  _delivererContext )
 {
     authChecksMessagesCbContext_t *context = *((authChecksMessagesCbContext_t **)pContext);
 

--- a/server_engine/test/test_qos0.c
+++ b/server_engine/test/test_qos0.c
@@ -67,7 +67,8 @@ static bool deliveryCallback(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext);
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext);
 
 static bool deliveryCallbackStopOnLimit(
     ismEngine_ConsumerHandle_t      hConsumer,
@@ -81,7 +82,8 @@ static bool deliveryCallbackStopOnLimit(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext);
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext);
 
 static bool deliveryCallbackStopDelivery(
     ismEngine_ConsumerHandle_t      hConsumer,
@@ -95,7 +97,8 @@ static bool deliveryCallbackStopDelivery(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext);
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext);
 
 static bool deliveryCallbackDestroyConsumer(
     ismEngine_ConsumerHandle_t      hConsumer,
@@ -109,7 +112,8 @@ static bool deliveryCallbackDestroyConsumer(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext);
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext);
 
 static bool deliveryCallbackDestroySession(
     ismEngine_ConsumerHandle_t      hConsumer,
@@ -123,7 +127,8 @@ static bool deliveryCallbackDestroySession(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext);
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext);
 
 static bool deliveryCallbackDestroyClientState(
     ismEngine_ConsumerHandle_t      hConsumer,
@@ -137,7 +142,8 @@ static bool deliveryCallbackDestroyClientState(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext);
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext);
 
 /*
  * Publish message with no subscriber
@@ -3635,7 +3641,8 @@ static bool deliveryCallback(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext)
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext)
 {
     bool moreMessagesPlease = true;
     callbackContext_t **ppCallbackContext = (callbackContext_t **)pConsumerContext;
@@ -3661,7 +3668,8 @@ static bool deliveryCallbackStopOnLimit(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext)
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext)
 {
     callbackContext_t **ppCallbackContext = (callbackContext_t **)pConsumerContext;
     callbackContext_t *pCallbackContext = *ppCallbackContext;
@@ -3691,7 +3699,8 @@ static bool deliveryCallbackStopDelivery(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext)
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext)
 {
     callbackContext_t **ppCallbackContext = (callbackContext_t **)pConsumerContext;
     callbackContext_t *pCallbackContext = *ppCallbackContext;
@@ -3719,7 +3728,8 @@ static bool deliveryCallbackDestroyConsumer(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext)
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext)
 {
     callbackContext_t **ppCallbackContext = (callbackContext_t **)pConsumerContext;
     callbackContext_t *pCallbackContext = *ppCallbackContext;
@@ -3747,7 +3757,8 @@ static bool deliveryCallbackDestroySession(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext)
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext)
 {
     callbackContext_t **ppCallbackContext = (callbackContext_t **)pConsumerContext;
     callbackContext_t *pCallbackContext = *ppCallbackContext;
@@ -3775,7 +3786,8 @@ static bool deliveryCallbackDestroyClientState(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext)
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext)
 {
     callbackContext_t **ppCallbackContext = (callbackContext_t **)pConsumerContext;
     callbackContext_t *pCallbackContext = *ppCallbackContext;

--- a/server_engine/test/test_qos0ExplicitSuspend.c
+++ b/server_engine/test/test_qos0ExplicitSuspend.c
@@ -61,7 +61,8 @@ static bool deliveryExplicitSuspendCallback(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext);
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext );
 
 static bool deliveryExplicitSuspendCallbackStopOnLimit(
     ismEngine_ConsumerHandle_t      hConsumer,
@@ -75,7 +76,8 @@ static bool deliveryExplicitSuspendCallbackStopOnLimit(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext);
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext );
 
 static bool deliveryCallbackExplicitSuspendStopDelivery(
     ismEngine_ConsumerHandle_t      hConsumer,
@@ -89,7 +91,8 @@ static bool deliveryCallbackExplicitSuspendStopDelivery(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext);
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext );
 
 static bool deliveryCallbackExplicitSuspendDestroyConsumer(
     ismEngine_ConsumerHandle_t      hConsumer,
@@ -103,7 +106,8 @@ static bool deliveryCallbackExplicitSuspendDestroyConsumer(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext);
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext );
 
 static bool deliveryCallbackExplicitSuspendDestroySession(
     ismEngine_ConsumerHandle_t      hConsumer,
@@ -117,7 +121,8 @@ static bool deliveryCallbackExplicitSuspendDestroySession(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext);
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext );
 
 static bool deliveryCallbackExplicitSuspendDestroyClientState(
     ismEngine_ConsumerHandle_t      hConsumer,
@@ -131,7 +136,8 @@ static bool deliveryCallbackExplicitSuspendDestroyClientState(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext);
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext );
 
 
 
@@ -2812,7 +2818,8 @@ static bool deliveryExplicitSuspendCallback(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext)
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext)
 {
     bool moreMessagesPlease = true;
     callbackContext_t **ppCallbackContext = (callbackContext_t **)pConsumerContext;
@@ -2838,7 +2845,8 @@ static bool deliveryExplicitSuspendCallbackStopOnLimit(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext)
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext)
 {
     bool reenable = true;
 
@@ -2880,7 +2888,8 @@ static bool deliveryCallbackExplicitSuspendStopDelivery(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext)
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext)
 {
     callbackContext_t **ppCallbackContext = (callbackContext_t **)pConsumerContext;
     callbackContext_t *pCallbackContext = *ppCallbackContext;
@@ -2909,7 +2918,8 @@ static bool deliveryCallbackExplicitSuspendDestroyConsumer(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext)
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext)
 {
     callbackContext_t **ppCallbackContext = (callbackContext_t **)pConsumerContext;
     callbackContext_t *pCallbackContext = *ppCallbackContext;
@@ -2938,7 +2948,8 @@ static bool deliveryCallbackExplicitSuspendDestroySession(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext)
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext )
 {
     callbackContext_t **ppCallbackContext = (callbackContext_t **)pConsumerContext;
     callbackContext_t *pCallbackContext = *ppCallbackContext;
@@ -2967,7 +2978,8 @@ static bool deliveryCallbackExplicitSuspendDestroyClientState(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext)
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext)
 {
     callbackContext_t **ppCallbackContext = (callbackContext_t **)pConsumerContext;
     callbackContext_t *pCallbackContext = *ppCallbackContext;

--- a/server_engine/test/test_qos1.c
+++ b/server_engine/test/test_qos1.c
@@ -49,7 +49,8 @@ static bool deliveryCallback(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext);
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext);
 
 /*
  * Publish message with a single QoS 1 subscription
@@ -228,7 +229,8 @@ static bool deliveryCallback(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext)
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext)
 {
     bool moreMessagesPlease = true;
     callbackContext_t **ppCallbackContext = (callbackContext_t **)pConsumerContext;

--- a/server_engine/test/test_qos2.c
+++ b/server_engine/test/test_qos2.c
@@ -63,7 +63,8 @@ static bool deliveryCallbackBeforeReconnect(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext);
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext);
 
 static bool deliveryCallbackAfterReconnect(
     ismEngine_ConsumerHandle_t      hConsumer,
@@ -77,7 +78,8 @@ static bool deliveryCallbackAfterReconnect(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext);
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext);
 
 static bool deliveryCallbackAfterRepeatedReconnect(
     ismEngine_ConsumerHandle_t      hConsumer,
@@ -91,7 +93,8 @@ static bool deliveryCallbackAfterRepeatedReconnect(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext);
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext);
 
 static void unreleasedCallback(
     uint32_t                        deliveryId,
@@ -857,7 +860,8 @@ static bool deliveryCallbackBeforeReconnect(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext)
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext )
 {
     bool moreMessagesPlease = true;
     callbackContext_t **ppCallbackContext = (callbackContext_t **)pConsumerContext;
@@ -906,7 +910,8 @@ static bool deliveryCallbackAfterReconnect(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext)
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext)
 {
     bool moreMessagesPlease = true;
     callbackContext_t **ppCallbackContext = (callbackContext_t **)pConsumerContext;
@@ -974,7 +979,8 @@ static bool deliveryCallbackAfterRepeatedReconnect(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext)
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext)
 {
     bool moreMessagesPlease = true;
     callbackContext_t **ppCallbackContext = (callbackContext_t **)pConsumerContext;

--- a/server_engine/test/test_queue1.c
+++ b/server_engine/test/test_queue1.c
@@ -239,7 +239,8 @@ static bool CallbackTestSimplePut(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext)
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext)
 {
     SimplePut_ContextInfo_t *pContext = (SimplePut_ContextInfo_t *)pConsumerContext;
 
@@ -300,7 +301,7 @@ static void testPut(ismQueueType_t qtype)
     ismEngine_MessageHandle_t hMsg1 = createTestMessage(0,0);
 
     //Put a message to the Queue without enabling waiter
-    rc = ieq_put(pThreadData, Q, ieqPutOptions_NONE, NULL, hMsg1, IEQ_MSGTYPE_REFCOUNT);
+    rc = ieq_put(pThreadData, Q, ieqPutOptions_NONE, NULL, hMsg1, IEQ_MSGTYPE_REFCOUNT, NULL);
     TEST_ASSERT_EQUAL(rc, OK);
     ism_engine_releaseMessage(hMsg1);
 
@@ -319,7 +320,7 @@ static void testPut(ismQueueType_t qtype)
     //Now put another and check it is delivered
     ismEngine_MessageHandle_t hMsg2 = createTestMessage(0,1);
     Context.msgsExpected = 1;
-    rc = ieq_put(pThreadData, Q, ieqPutOptions_NONE, NULL, hMsg2, IEQ_MSGTYPE_REFCOUNT);
+    rc = ieq_put(pThreadData, Q, ieqPutOptions_NONE, NULL, hMsg2, IEQ_MSGTYPE_REFCOUNT, NULL);
     TEST_ASSERT_EQUAL(rc, OK);
     ism_engine_releaseMessage(hMsg2);
     TEST_ASSERT_EQUAL(0, Context.msgsExpected);
@@ -347,7 +348,8 @@ static bool CallbackTestPutSomeGetFew(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext)
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext)
 {
     SimplePut_ContextInfo_t *pContext = (SimplePut_ContextInfo_t *)pConsumerContext;
 
@@ -411,7 +413,7 @@ static void testPutSomeGetFew(ismQueueType_t qtype)
     for (i=0; i< msgsToPut; i++)
     {
         ismEngine_MessageHandle_t hMsg = createTestMessage(0,i);
-        rc = ieq_put(pThreadData, Q, ieqPutOptions_NONE, NULL, hMsg, IEQ_MSGTYPE_REFCOUNT);
+        rc = ieq_put(pThreadData, Q, ieqPutOptions_NONE, NULL, hMsg, IEQ_MSGTYPE_REFCOUNT, NULL);
         TEST_ASSERT_EQUAL(rc, OK);
         ism_engine_releaseMessage(hMsg);
     }
@@ -449,7 +451,8 @@ static bool CallbackTestMaxMessages(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext)
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext)
 {
     SimplePut_ContextInfo_t *pContext = (SimplePut_ContextInfo_t *)pConsumerContext;
 
@@ -529,7 +532,7 @@ static void testMaxMessages(ismQueueType_t qtype)
     for (i=0; i < initialMaxMessages; i++)
     {
         hMsg = createTestMessage(0,msgNum++);
-        rc = ieq_put(pThreadData, Q, ieqPutOptions_NONE, NULL, hMsg, IEQ_MSGTYPE_REFCOUNT);
+        rc = ieq_put(pThreadData, Q, ieqPutOptions_NONE, NULL, hMsg, IEQ_MSGTYPE_REFCOUNT, NULL);
         TEST_ASSERT_EQUAL(rc, OK);
         ism_engine_releaseMessage(hMsg);
     }
@@ -537,7 +540,7 @@ static void testMaxMessages(ismQueueType_t qtype)
 
     //And now a message that shouldn't
     hMsg = createTestMessage(0,msgNum);
-    rc = ieq_put(pThreadData, Q, ieqPutOptions_NONE, NULL, hMsg, IEQ_MSGTYPE_REFCOUNT);
+    rc = ieq_put(pThreadData, Q, ieqPutOptions_NONE, NULL, hMsg, IEQ_MSGTYPE_REFCOUNT, NULL);
     TEST_ASSERT_EQUAL(rc, ISMRC_DestinationFull);
     ism_engine_releaseMessage(hMsg);
 
@@ -550,13 +553,13 @@ static void testMaxMessages(ismQueueType_t qtype)
 
     //Check we can put another message...
     hMsg = createTestMessage(0,msgNum++);
-    rc = ieq_put(pThreadData, Q, ieqPutOptions_NONE, NULL, hMsg, IEQ_MSGTYPE_REFCOUNT);
+    rc = ieq_put(pThreadData, Q, ieqPutOptions_NONE, NULL, hMsg, IEQ_MSGTYPE_REFCOUNT, NULL);
     TEST_ASSERT_EQUAL(rc, OK);
     ism_engine_releaseMessage(hMsg);
 
     //But the queue should now be full...
     hMsg = createTestMessage(0,msgNum);
-    rc = ieq_put(pThreadData, Q, ieqPutOptions_NONE, NULL, hMsg, IEQ_MSGTYPE_REFCOUNT);
+    rc = ieq_put(pThreadData, Q, ieqPutOptions_NONE, NULL, hMsg, IEQ_MSGTYPE_REFCOUNT, NULL);
     TEST_ASSERT_EQUAL(rc, ISMRC_DestinationFull);
     ism_engine_releaseMessage(hMsg);
 
@@ -565,7 +568,7 @@ static void testMaxMessages(ismQueueType_t qtype)
     for (i=0; i < initialMaxMessages; i++)
     {
         hMsg = createTestMessage(0,msgNum++);
-        rc = ieq_put(pThreadData, Q, ieqPutOptions_NONE, NULL, hMsg, IEQ_MSGTYPE_REFCOUNT);
+        rc = ieq_put(pThreadData, Q, ieqPutOptions_NONE, NULL, hMsg, IEQ_MSGTYPE_REFCOUNT, NULL);
         TEST_ASSERT_EQUAL(rc, OK);
         ism_engine_releaseMessage(hMsg);
     }
@@ -573,7 +576,7 @@ static void testMaxMessages(ismQueueType_t qtype)
 
     //But the queue should now be full...
     hMsg = createTestMessage(0,msgNum);
-    rc = ieq_put(pThreadData, Q, ieqPutOptions_NONE, NULL, hMsg, IEQ_MSGTYPE_REFCOUNT);
+    rc = ieq_put(pThreadData, Q, ieqPutOptions_NONE, NULL, hMsg, IEQ_MSGTYPE_REFCOUNT, NULL);
     TEST_ASSERT_EQUAL(rc, ISMRC_DestinationFull);
     ism_engine_releaseMessage(hMsg);
     checkTotalMessages(Q, 2*initialMaxMessages);
@@ -581,7 +584,7 @@ static void testMaxMessages(ismQueueType_t qtype)
     //Decrease the max messages and check still can't put
     fakePolicy1->maxMessageCount = initialMaxMessages;
     hMsg = createTestMessage(0,msgNum);
-    rc = ieq_put(pThreadData, Q, ieqPutOptions_NONE, NULL, hMsg, IEQ_MSGTYPE_REFCOUNT);
+    rc = ieq_put(pThreadData, Q, ieqPutOptions_NONE, NULL, hMsg, IEQ_MSGTYPE_REFCOUNT, NULL);
     TEST_ASSERT_EQUAL(rc, ISMRC_DestinationFull);
     ism_engine_releaseMessage(hMsg);
     checkTotalMessages(Q, 2*initialMaxMessages);
@@ -595,14 +598,14 @@ static void testMaxMessages(ismQueueType_t qtype)
 
     //Check we can put a message
     hMsg = createTestMessage(0,msgNum++);
-    rc = ieq_put(pThreadData, Q, ieqPutOptions_NONE, NULL, hMsg, IEQ_MSGTYPE_REFCOUNT);
+    rc = ieq_put(pThreadData, Q, ieqPutOptions_NONE, NULL, hMsg, IEQ_MSGTYPE_REFCOUNT, NULL);
     TEST_ASSERT_EQUAL(rc, OK);
     ism_engine_releaseMessage(hMsg);
     checkTotalMessages(Q, initialMaxMessages);
 
     //But check it's now full
     hMsg = createTestMessage(0,msgNum);
-    rc = ieq_put(pThreadData, Q, ieqPutOptions_NONE, NULL, hMsg, IEQ_MSGTYPE_REFCOUNT);
+    rc = ieq_put(pThreadData, Q, ieqPutOptions_NONE, NULL, hMsg, IEQ_MSGTYPE_REFCOUNT, NULL);
     TEST_ASSERT_EQUAL(rc, ISMRC_DestinationFull);
     ism_engine_releaseMessage(hMsg);
     checkTotalMessages(Q, initialMaxMessages);
@@ -629,7 +632,8 @@ static bool CallbackTestFlow(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext)
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext)
 {
     SimplePut_ContextInfo_t *pContext = (SimplePut_ContextInfo_t *)pConsumerContext;
 
@@ -708,7 +712,7 @@ static void testFlow(ismQueueType_t qtype)
     for (i=0; i < target_depth; i++)
     {
         ismEngine_MessageHandle_t hMsg= createTestMessage(0,msgNum++);
-        rc = ieq_put(pThreadData, Q, ieqPutOptions_NONE, NULL, hMsg, IEQ_MSGTYPE_REFCOUNT);
+        rc = ieq_put(pThreadData, Q, ieqPutOptions_NONE, NULL, hMsg, IEQ_MSGTYPE_REFCOUNT, NULL);
         TEST_ASSERT_EQUAL(rc, OK);
         ism_engine_releaseMessage(hMsg);
     }
@@ -731,7 +735,7 @@ static void testFlow(ismQueueType_t qtype)
     for (i=0; i < msgs; i++)
     {
         ismEngine_MessageHandle_t hMsg= createTestMessage(0,msgNum++);
-        rc = ieq_put(pThreadData, Q, ieqPutOptions_NONE, NULL, hMsg, IEQ_MSGTYPE_REFCOUNT);
+        rc = ieq_put(pThreadData, Q, ieqPutOptions_NONE, NULL, hMsg, IEQ_MSGTYPE_REFCOUNT, NULL);
         TEST_ASSERT_EQUAL(rc, OK);
         ism_engine_releaseMessage(hMsg);
     }
@@ -774,7 +778,7 @@ static void *MultiFlowPutter(void *threadarg)
     {
         ismEngine_MessageHandle_t hMsg= createTestMessage( putterInfo->putterNum
                                                          , i);
-        rc = ieq_put(pThreadData, putterInfo->Q, ieqPutOptions_NONE, NULL, hMsg, IEQ_MSGTYPE_REFCOUNT);
+        rc = ieq_put(pThreadData, putterInfo->Q, ieqPutOptions_NONE, NULL, hMsg, IEQ_MSGTYPE_REFCOUNT, NULL);
         TEST_ASSERT_EQUAL(rc, OK);
         ism_engine_releaseMessage(hMsg);
     }
@@ -796,7 +800,8 @@ static bool CallbackTestMultiFlow(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext)
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext)
 {
     MultiPut_ContextInfo_t *pContext = (MultiPut_ContextInfo_t *)pConsumerContext;
 
@@ -940,7 +945,8 @@ static bool CallbackTestNestedPut(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext)
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext)
 {
     ieutThreadData_t *pThreadData = ieut_getThreadData();
     NestedPut_ContextInfo_t *context = (NestedPut_ContextInfo_t *)pConsumerContext;
@@ -957,7 +963,7 @@ static bool CallbackTestNestedPut(
                                                              - context->remainingMessages);
 
         //Put a message to the Queue nested in this callback
-        int32_t rc = ieq_put(pThreadData, context->Q, ieqPutOptions_NONE, NULL, hMsg, IEQ_MSGTYPE_REFCOUNT);
+        int32_t rc = ieq_put(pThreadData, context->Q, ieqPutOptions_NONE, NULL, hMsg, IEQ_MSGTYPE_REFCOUNT, NULL);
         TEST_ASSERT_EQUAL(rc, OK);
         ism_engine_releaseMessage(hMsg);
     }
@@ -1023,7 +1029,7 @@ static void testNestedPut(ismQueueType_t qtype)
     ismEngine_MessageHandle_t hMsg = createTestMessage(0,0);
 
     //Put a message to the Queue without enabling waiter
-    rc = ieq_put(pThreadData, Q, ieqPutOptions_NONE, NULL, hMsg, IEQ_MSGTYPE_REFCOUNT);
+    rc = ieq_put(pThreadData, Q, ieqPutOptions_NONE, NULL, hMsg, IEQ_MSGTYPE_REFCOUNT, NULL);
     TEST_ASSERT_EQUAL(rc, OK);
     ism_engine_releaseMessage(hMsg);
 
@@ -1116,7 +1122,8 @@ static bool CallbackTestDisable(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext)
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext)
 {
     uint32_t *msgsReceived = (uint32_t *)pConsumerContext;
 
@@ -1176,7 +1183,7 @@ static void *TestDisablePutter(void *threadarg)
             {
                 ismEngine_MessageHandle_t hMsg= createTestMessage( putterInfo->putterNum
                                                                  , i);
-                rc = ieq_put(pThreadData, putterInfo->Q, ieqPutOptions_NONE, NULL, hMsg, IEQ_MSGTYPE_REFCOUNT);
+                rc = ieq_put(pThreadData, putterInfo->Q, ieqPutOptions_NONE, NULL, hMsg, IEQ_MSGTYPE_REFCOUNT, NULL);
                 TEST_ASSERT_EQUAL(rc, OK);
                 ism_engine_releaseMessage(hMsg);
             }

--- a/server_engine/test/test_queue2.c
+++ b/server_engine/test/test_queue2.c
@@ -288,7 +288,8 @@ static void putMsgArray( ismQHandle_t hQueue
                     , ieqPutOptions_NONE
                     , pTran
                     , pMsgs[counter].pMessage
-                    , IEQ_MSGTYPE_REFCOUNT );
+                    , IEQ_MSGTYPE_REFCOUNT 
+                    , NULL );
         TEST_ASSERT_EQUAL(rc, OK);
 
         verbose(5, "Put message %d", counter);
@@ -384,7 +385,8 @@ static bool MessageCallback(ismEngine_ConsumerHandle_t  hConsumer,
                             ismMessageAreaType_t        areaTypes[areaCount],
                             size_t                      areaLengths[areaCount],
                             void *                      pAreaData[areaCount],
-                            void *                      pConsumerContext)
+                            void *                      pConsumerContext,
+                            ismEngine_DelivererContext_t * _delivererContext)
 {
     int32_t rc;
     tiqConsumerContext_t *pContext = *(tiqConsumerContext_t **)pConsumerContext;
@@ -603,7 +605,8 @@ static bool MessageCallback2(ismEngine_ConsumerHandle_t  hConsumer,
                              ismMessageAreaType_t        areaTypes[areaCount],
                              size_t                      areaLengths[areaCount],
                              void *                      pAreaData[areaCount],
-                             void *                      pConsumerContext)
+                             void *                      pConsumerContext,
+                             ismEngine_DelivererContext_t * _delivererContext)
 {
     int32_t rc;
     tiqConsumerContext_t *pContext = *(tiqConsumerContext_t **)pConsumerContext;
@@ -772,7 +775,8 @@ static void *putterThread( void *arg )
                     , ieqPutOptions_NONE
                     , NULL
                     , pMessage
-                    , IEQ_MSGTYPE_REFCOUNT );
+                    , IEQ_MSGTYPE_REFCOUNT
+                    , NULL );
         TEST_ASSERT(rc == OK, ("ieq_put returned %rc",rc));
 
 
@@ -979,7 +983,8 @@ static bool receiveCallback( ismEngine_ConsumerHandle_t  hConsumer
                            , ismMessageAreaType_t        areaTypes[areaCount]
                            , size_t                      areaLengths[areaCount]
                            , void *                      pAreaData[areaCount]
-                           , void *                      pConsumerContext)
+                           , void *                      pConsumerContext
+                           , ismEngine_DelivererContext_t * _delivererContext)
 {
     uint32_t rc;
     bool cont = true;
@@ -2755,7 +2760,8 @@ static void Queue2_BatchNack( ismQueueType_t type
                     , ieqPutOptions_NONE
                     , NULL
                     , msgArray[loop].pMessage
-                    , IEQ_MSGTYPE_REFCOUNT );
+                    , IEQ_MSGTYPE_REFCOUNT
+                    , NULL );
         TEST_ASSERT_EQUAL(rc, OK);
 
         verbose(5, "Put message %d", loop);
@@ -3099,7 +3105,8 @@ static void Queue2_BatchTranAck( ismQueueType_t type
                     , ieqPutOptions_NONE
                     , NULL
                     , msgArray[loop].pMessage
-                    , IEQ_MSGTYPE_REFCOUNT );
+                    , IEQ_MSGTYPE_REFCOUNT
+                    , NULL );
         TEST_ASSERT_EQUAL(rc, OK);
 
         verbose(5, "Put message %d", loop);
@@ -3257,7 +3264,8 @@ static bool RedeliverReopenCB(ismEngine_ConsumerHandle_t  hConsumer,
                               ismMessageAreaType_t        areaTypes[areaCount],
                               size_t                      areaLengths[areaCount],
                               void *                      pAreaData[areaCount],
-                              void *                      pConsumerContext)
+                              void *                      pConsumerContext,
+                              ismEngine_DelivererContext_t * _delivererContext )
 {
     tiqRedeliverContext_t *pContext = *(tiqRedeliverContext_t **)pConsumerContext;
 

--- a/server_engine/test/test_queue3.c
+++ b/server_engine/test/test_queue3.c
@@ -368,7 +368,8 @@ static void putMsgArray( ismEngine_SessionHandle_t hSession
                     , putFlags
                     , pTransaction
                     , pMsgs[counter].pMessage
-                    , IEQ_MSGTYPE_REFCOUNT );
+                    , IEQ_MSGTYPE_REFCOUNT
+                    , NULL );
         TEST_ASSERT(rc == 0, ("Failed to put message %d - rc = %d",
                     counter,  rc));
 
@@ -535,7 +536,8 @@ static bool MessageCallback(ismEngine_ConsumerHandle_t  hConsumer,
                             ismMessageAreaType_t        areaTypes[areaCount],
                             size_t                      areaLengths[areaCount],
                             void *                      pAreaData[areaCount],
-                            void *                      pConsumerContext)
+                            void *                      pConsumerContext,
+                            ismEngine_DelivererContext_t * _delivererContext)
 {
     tiqConsumerContext_t *pContext = *(tiqConsumerContext_t **)pConsumerContext;
     uint32_t msgNum;

--- a/server_engine/test/test_queue4.c
+++ b/server_engine/test/test_queue4.c
@@ -198,7 +198,8 @@ static bool VerifyCallback(ismEngine_ConsumerHandle_t  hConsumer,
                            ismMessageAreaType_t        areaTypes[areaCount],
                            size_t                      areaLengths[areaCount],
                            void *                      pAreaData[areaCount],
-                           void *                      pConsumerContext)
+                           void *                      pConsumerContext,
+                           ismEngine_DelivererContext_t * _delivererContext)
 {
     VerifyContext_t *pContext = *(VerifyContext_t **)pConsumerContext;
 
@@ -410,7 +411,8 @@ static bool WorkerCallback(ismEngine_ConsumerHandle_t  hConsumer,
                            ismMessageAreaType_t        areaTypes[areaCount],
                            size_t                      areaLengths[areaCount],
                            void *                      pAreaData[areaCount],
-                           void *                      pConsumerContext)
+                           void *                      pConsumerContext,
+                           ismEngine_DelivererContext_t * _delivererContext)
 {
     ieutThreadData_t *pThreadData = ieut_getThreadData();
     uint32_t rc=0;

--- a/server_engine/test/test_queue4a.c
+++ b/server_engine/test/test_queue4a.c
@@ -215,7 +215,8 @@ static bool VerifyCallback(ismEngine_ConsumerHandle_t  hConsumer,
                            ismMessageAreaType_t        areaTypes[areaCount],
                            size_t                      areaLengths[areaCount],
                            void *                      pAreaData[areaCount],
-                           void *                      pConsumerContext)
+                           void *                      pConsumerContext,
+                           ismEngine_DelivererContext_t * _delivererContext)
 {
     VerifyContext_t *pContext = *(VerifyContext_t **)pConsumerContext;
 
@@ -395,7 +396,8 @@ static bool WorkerCallback(ismEngine_ConsumerHandle_t  hConsumer,
                            ismMessageAreaType_t        areaTypes[areaCount],
                            size_t                      areaLengths[areaCount],
                            void *                      pAreaData[areaCount],
-                           void *                      pConsumerContext)
+                           void *                      pConsumerContext,
+                           ismEngine_DelivererContext_t * _delivererContext)
 {
     uint32_t rc=0;
     int osrc;

--- a/server_engine/test/test_queueMsgExpiry.c
+++ b/server_engine/test/test_queueMsgExpiry.c
@@ -151,7 +151,8 @@ bool checkExpiryCB(
         ismMessageAreaType_t            areaTypes[areaCount],
         size_t                          areaLengths[areaCount],
         void *                          pAreaData[areaCount],
-        void *                          pConsumerContext)
+        void *                          pConsumerContext,
+        ismEngine_DelivererContext_t *  _delivererContext)
 {
     test_SubscriptionData_t *pSubData = *(test_SubscriptionData_t **)pConsumerContext;
     uint32_t  expectedExpiry = pSubData->ConsumerExpectedExpiry;
@@ -184,7 +185,8 @@ bool claimExpiredCB(
         ismMessageAreaType_t            areaTypes[areaCount],
         size_t                          areaLengths[areaCount],
         void *                          pAreaData[areaCount],
-        void *                          pConsumerContext)
+        void *                          pConsumerContext,
+        ismEngine_DelivererContext_t *  _delivererContext)
 {
     test_SubscriptionData_t *pSubData = *(test_SubscriptionData_t **)pConsumerContext;
 
@@ -217,7 +219,8 @@ bool neverCalledCB(
         ismMessageAreaType_t            areaTypes[areaCount],
         size_t                          areaLengths[areaCount],
         void *                          pAreaData[areaCount],
-        void *                          pConsumerContext)
+        void *                          pConsumerContext,
+        ismEngine_DelivererContext_t *  _delivererContext)
 {
     //This callback should never fire
     TEST_ASSERT_EQUAL(1, 0);

--- a/server_engine/test/test_remoteServers.c
+++ b/server_engine/test/test_remoteServers.c
@@ -2301,7 +2301,8 @@ bool remoteServerDeliveryCallback(ismEngine_ConsumerHandle_t      hConsumer,
                                   ismMessageAreaType_t            areaTypes[areaCount],
                                   size_t                          areaLengths[areaCount],
                                   void *                          pAreaData[areaCount],
-                                  void *                          pContext)
+                                  void *                          pContext,
+                                  ismEngine_DelivererContext_t *  _delivererContext)
 {
     remoteServerMessagesCbContext_t *context = *((remoteServerMessagesCbContext_t **)pContext);
 
@@ -5263,7 +5264,8 @@ void test_capability_RecoverUnClustered_Phase1(void)
                      ieqPutOptions_THREAD_LOCAL_MESSAGE,
                      hTran[t],
                      hMessage,
-                     IEQ_MSGTYPE_REFCOUNT);
+                     IEQ_MSGTYPE_REFCOUNT,
+                     NULL);
         TEST_ASSERT_EQUAL(rc, OK);
 
         ism_engine_releaseMessage(hMessage);

--- a/server_engine/test/test_retainedMsgs.c
+++ b/server_engine/test/test_retainedMsgs.c
@@ -408,7 +408,8 @@ bool checkDeliveryMessagesCallback(ismEngine_ConsumerHandle_t      hConsumer,
                                    ismMessageAreaType_t            areaTypes[areaCount],
                                    size_t                          areaLengths[areaCount],
                                    void *                          pAreaData[areaCount],
-                                   void *                          pContext)
+                                   void *                          pContext,
+                                   ismEngine_DelivererContext_t *  _delivererContext)
 {
     checkDeliveryMessagesCbContext_t *context = *((checkDeliveryMessagesCbContext_t **)pContext);
 
@@ -796,7 +797,8 @@ bool retainedMessagesCallback(ismEngine_ConsumerHandle_t      hConsumer,
                               ismMessageAreaType_t            areaTypes[areaCount],
                               size_t                          areaLengths[areaCount],
                               void *                          pAreaData[areaCount],
-                              void *                          pContext)
+                              void *                          pContext,
+                              ismEngine_DelivererContext_t *  _delivererContext )
 {
     retainedMessagesCbContext_t *context = *((retainedMessagesCbContext_t **)pContext);
 
@@ -1281,7 +1283,8 @@ bool republishMessagesCallback(ismEngine_ConsumerHandle_t      hConsumer,
                                ismMessageAreaType_t            areaTypes[areaCount],
                                size_t                          areaLengths[areaCount],
                                void *                          pAreaData[areaCount],
-                               void *                          pContext)
+                               void *                          pContext,
+                               ismEngine_DelivererContext_t *  _delivererContext)
 {
     republishMessagesCbContext_t *context = *((republishMessagesCbContext_t **)pContext);
 
@@ -1549,7 +1552,8 @@ bool retSelMessagesCallback(ismEngine_ConsumerHandle_t      hConsumer,
                             ismMessageAreaType_t            areaTypes[areaCount],
                             size_t                          areaLengths[areaCount],
                             void *                          pAreaData[areaCount],
-                            void *                          pContext)
+                            void *                          pContext,
+                            ismEngine_DelivererContext_t *  _delivererContext)
 {
     retSelMessagesCbContext_t *context = *((retSelMessagesCbContext_t **)pContext);
 
@@ -2494,7 +2498,8 @@ bool getRetainedMsgCB(ismEngine_ConsumerHandle_t      hConsumer,
                       ismMessageAreaType_t            areaTypes[areaCount],
                       size_t                          areaLengths[areaCount],
                       void *                          pAreaData[areaCount],
-                      void *                          pContext)
+                      void *                          pContext,
+                      ismEngine_DelivererContext_t *  _delivererContext)
 {
     getRetainedMsgCBContext_t *context = *(getRetainedMsgCBContext_t **)pContext;
 
@@ -4935,7 +4940,8 @@ bool latesubsMessagesCallback(ismEngine_ConsumerHandle_t      hConsumer,
                               ismMessageAreaType_t            areaTypes[areaCount],
                               size_t                          areaLengths[areaCount],
                               void *                          pAreaData[areaCount],
-                              void *                          pContext)
+                              void *                          pContext,
+                              ismEngine_DelivererContext_t *  _delivererContext)
 {
     latesubsMessagesCbContext_t *context = *((latesubsMessagesCbContext_t **)pContext);
 

--- a/server_engine/test/test_session.c
+++ b/server_engine/test/test_session.c
@@ -382,7 +382,8 @@ bool ConsumerCallback( ismEngine_ConsumerHandle_t hConsumer
                      , ismMessageAreaType_t       areaTypes[areaCount]
                      , size_t                     areaLengths[areaCount]
                      , void *                     pAreaData[areaCount]
-                     , void *                     pConsumerContext)
+                     , void *                     pConsumerContext
+                     , ismEngine_DelivererContext_t * _delivererContext)
 {
     int urc;
     uint32_t rc;
@@ -1279,7 +1280,8 @@ bool DelayedAckCallback( ismEngine_ConsumerHandle_t hConsumer
                        , ismMessageAreaType_t       areaTypes[areaCount]
                        , size_t                     areaLengths[areaCount]
                        , void *                     pAreaData[areaCount]
-                       , void *                     pConsumerContext)
+                       , void *                     pConsumerContext
+                       , ismEngine_DelivererContext_t * _delivererContext )
 {
     int rc;
     DAConsumer_t *pConsumer = *(DAConsumer_t **)pConsumerContext;

--- a/server_engine/test/test_sharedMQTTFlow.c
+++ b/server_engine/test/test_sharedMQTTFlow.c
@@ -450,7 +450,8 @@ bool ConsumeCallback(
         ismMessageAreaType_t            areaTypes[areaCount],
         size_t                          areaLengths[areaCount],
         void *                          pAreaData[areaCount],
-        void *                          pConsumerContext)
+        void *                          pConsumerContext,
+        ismEngine_DelivererContext_t *  _delivererContext )
 {
     receiveMsgContext_t *context = *(receiveMsgContext_t **)pConsumerContext;
 

--- a/server_engine/test/test_sharedSubs.c
+++ b/server_engine/test/test_sharedSubs.c
@@ -84,7 +84,8 @@ bool test_msgCallback(ismEngine_ConsumerHandle_t      hConsumer,
                       ismMessageAreaType_t            areaTypes[areaCount],
                       size_t                          areaLengths[areaCount],
                       void *                          pAreaData[areaCount],
-                      void *                          pContext)
+                      void *                          pContext,
+                      ismEngine_DelivererContext_t *  _delivererContext)
 {
     msgCallbackContext_t *context = *((msgCallbackContext_t **)pContext);
     int32_t rc;

--- a/server_engine/test/test_temporaryQueues.c
+++ b/server_engine/test/test_temporaryQueues.c
@@ -58,7 +58,8 @@ bool queueMessagesCallback(ismEngine_ConsumerHandle_t      hConsumer,
                            ismMessageAreaType_t            areaTypes[areaCount],
                            size_t                          areaLengths[areaCount],
                            void *                          pAreaData[areaCount],
-                           void *                          pContext)
+                           void *                          pContext,
+                           ismEngine_DelivererContext_t *  _delivererContext )
 {
     queueMessagesCbContext_t *context = *((queueMessagesCbContext_t **)pContext);
 

--- a/server_engine/test/test_topicTree.c
+++ b/server_engine/test/test_topicTree.c
@@ -65,7 +65,8 @@ bool genericMessageCallback(ismEngine_ConsumerHandle_t hConsumer,
                             ismMessageAreaType_t areaTypes[areaCount],
                             size_t areaLengths[areaCount],
                             void *pAreaData[areaCount],
-                            void *pContext)
+                            void *pContext,
+                            ismEngine_DelivererContext_t * _delivererContext)
 {
     genericMsgCbContext_t *context = *((genericMsgCbContext_t **)pContext);
 
@@ -401,7 +402,8 @@ int32_t test_selectionCallback(ismMessageHeader_t * pMsgDetails,
                                void *               pareaData[areaCount],
                                const char *         topic,
                                const void *         pselectorRule,
-                               size_t               selectorRuleLen )
+                               size_t               selectorRuleLen,
+                               ismMessageSelectionLockStrategy_t * lockStrategy )
 {
     TEST_ASSERT_PTR_NOT_NULL(OriginalSelectionCallback);
 
@@ -433,7 +435,7 @@ int32_t test_selectionCallback(ismMessageHeader_t * pMsgDetails,
         }
     }
 
-    return OriginalSelectionCallback(pMsgDetails, areaCount, areaTypes, areaLengths, pareaData, topic, pselectorRule, selectorRuleLen);
+    return OriginalSelectionCallback(pMsgDetails, areaCount, areaTypes, areaLengths, pareaData, topic, pselectorRule, selectorRuleLen, lockStrategy);
 }
 
 /*********************************************************************/
@@ -2885,7 +2887,8 @@ bool nolocalMessagesCallback(ismEngine_ConsumerHandle_t      hConsumer,
                              ismMessageAreaType_t            areaTypes[areaCount],
                              size_t                          areaLengths[areaCount],
                              void *                          pAreaData[areaCount],
-                             void *                          pContext)
+                             void *                          pContext,
+                             ismEngine_DelivererContext_t *  _delivererContext)
 {
     nolocalMessagesCbContext_t *context = *((nolocalMessagesCbContext_t **)pContext);
 
@@ -4480,7 +4483,8 @@ bool maxMessagesCallback(ismEngine_ConsumerHandle_t      hConsumer,
                          ismMessageAreaType_t            areaTypes[areaCount],
                          size_t                          areaLengths[areaCount],
                          void *                          pAreaData[areaCount],
-                         void *                          pContext)
+                         void *                          pContext,
+                         ismEngine_DelivererContext_t *  _delivererContext)
 {
     maxMessagesCbContext_t *context = *((maxMessagesCbContext_t **)pContext);
 
@@ -5061,7 +5065,8 @@ bool NDSubsMessagesCallback(ismEngine_ConsumerHandle_t      hConsumer,
                             ismMessageAreaType_t            areaTypes[areaCount],
                             size_t                          areaLengths[areaCount],
                             void *                          pAreaData[areaCount],
-                            void *                          pContext)
+                            void *                          pContext,
+                            ismEngine_DelivererContext_t *  _delivererContext)
 {
     NDSubsMessagesCbContext_t *context = *((NDSubsMessagesCbContext_t **)pContext);
 

--- a/server_engine/test/test_tranRestart.c
+++ b/server_engine/test/test_tranRestart.c
@@ -245,7 +245,8 @@ static bool VerifyCallback(ismEngine_ConsumerHandle_t  hConsumer,
                            ismMessageAreaType_t        areaTypes[areaCount],
                            size_t                      areaLengths[areaCount],
                            void *                      pAreaData[areaCount],
-                           void *                      pConsumerContext)
+                           void *                      pConsumerContext,
+                           ismEngine_DelivererContext_t * _delivererContext)
 {
     uint32_t rc;
     VerifyContext_t *pContext = *(VerifyContext_t **)pConsumerContext;

--- a/server_engine/test/test_transaction.c
+++ b/server_engine/test/test_transaction.c
@@ -281,7 +281,8 @@ static bool MessageCallback(ismEngine_ConsumerHandle_t  hConsumer,
                             ismMessageAreaType_t        areaTypes[areaCount],
                             size_t                      areaLengths[areaCount],
                             void *                      pAreaData[areaCount],
-                            void *                      pConsumerContext)
+                            void *                      pConsumerContext,
+                            ismEngine_DelivererContext_t * _delivererContext)
 {
     int32_t rc;
     tiqConsumerContext_t *pContext = *(tiqConsumerContext_t **)pConsumerContext;

--- a/server_engine/test/test_transactionRecovery.c
+++ b/server_engine/test/test_transactionRecovery.c
@@ -89,7 +89,8 @@ bool DeletedTransactionRestartCallback(
         ismMessageAreaType_t            areaTypes[areaCount],
         size_t                          areaLengths[areaCount],
         void *                          pAreaData[areaCount],
-        void *                          pConsumerContext)
+        void *                          pConsumerContext,
+        ismEngine_DelivererContext_t *  _delivererContext )
 {
     ismEngine_TransactionHandle_t hTran = **((ismEngine_TransactionHandle_t **)pConsumerContext);
 
@@ -626,7 +627,8 @@ static bool deliveryCallback(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext)
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext)
 {
     callbackContext_t **ppCallbackContext = (callbackContext_t **)pConsumerContext;
     callbackContext_t *pCallbackContext = *ppCallbackContext;

--- a/server_engine/test/test_willMessage.c
+++ b/server_engine/test/test_willMessage.c
@@ -83,7 +83,8 @@ static bool deliveryCallback(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext);
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext );
 
 
 /*
@@ -2062,7 +2063,8 @@ static bool deliveryCallback(
     ismMessageAreaType_t            areaTypes[areaCount],
     size_t                          areaLengths[areaCount],
     void *                          pAreaData[areaCount],
-    void *                          pConsumerContext)
+    void *                          pConsumerContext,
+    ismEngine_DelivererContext_t *  _delivererContext )
 {
     bool moreMessagesPlease = true;
     int32_t rc = ISMRC_OK;

--- a/server_engine/test/utils/test_utils_pubsuback.c
+++ b/server_engine/test/utils/test_utils_pubsuback.c
@@ -115,7 +115,8 @@ bool test_markMessagesCallback(
         ismMessageAreaType_t            areaTypes[areaCount],
         size_t                          areaLengths[areaCount],
         void *                          pAreaData[areaCount],
-        void *                          pConsumerContext)
+        void *                          pConsumerContext,
+        ismEngine_DelivererContext_t *  _delivererContext )
 {
     testMarkMsgsContext_t *context = *(testMarkMsgsContext_t **)pConsumerContext;
     bool considerMsg = true;
@@ -224,7 +225,8 @@ static bool countMessagesCallback(
         ismMessageAreaType_t            areaTypes[areaCount],
         size_t                          areaLengths[areaCount],
         void *                          pAreaData[areaCount],
-        void *                          pConsumerContext)
+        void *                          pConsumerContext,
+        ismEngine_DelivererContext_t *  _delivererContext )
 {
     testGetMsgContext_t *context = *(testGetMsgContext_t **)pConsumerContext;
     bool doAck = false;

--- a/server_engine/test/utils/test_utils_pubsuback.h
+++ b/server_engine/test/utils/test_utils_pubsuback.h
@@ -73,7 +73,8 @@ bool test_markMessagesCallback(
         ismMessageAreaType_t            areaTypes[areaCount],
         size_t                          areaLengths[areaCount],
         void *                          pAreaData[areaCount],
-        void *                          pConsumerContext);
+        void *                          pConsumerContext,
+        ismEngine_DelivererContext_t *  _delivererContext );
 
 void test_pubMessages( const char *topicString
                      , uint8_t persistence

--- a/server_ismc/src/message.c
+++ b/server_ismc/src/message.c
@@ -364,7 +364,7 @@ ismc_message_t * ismc_makeMessage(ismc_consumer_t * consumer, action_t * action)
  * Do message selection on a message
  */
 int ismc_filterMessage(ismc_message_t * message, ismRule_t * rule) {
-    return ism_common_filter(rule, message->h.props, NULL, NULL);
+    return ism_common_filter(rule, message->h.props, NULL, NULL, NULL);
 }
 
 

--- a/server_protocol/src/forwarder.h
+++ b/server_protocol/src/forwarder.h
@@ -514,7 +514,7 @@ bool ism_fwd_replyMessage(ismEngine_ConsumerHandle_t consumerh,
         uint32_t seqnum, ismMessageState_t state, uint32_t options,
         ismMessageHeader_t * hdr, uint8_t areas,
         ismMessageAreaType_t areatype[areas], size_t areasize[areas],
-        void * areaptr[areas], void * vaction);
+        void * areaptr[areas], void * vaction, ismEngine_DelivererContext_t * _delivererContext);
 /*
  * Return the forwarder endpoint
  */

--- a/server_protocol/src/fwdsender.c
+++ b/server_protocol/src/fwdsender.c
@@ -404,7 +404,7 @@ bool ism_fwd_replyMessage(ismEngine_ConsumerHandle_t consumerh,
         uint32_t seqnum, ismMessageState_t state, uint32_t options,
         ismMessageHeader_t * hdr, uint8_t areas,
         ismMessageAreaType_t areatype[areas], size_t areasize[areas],
-        void * areaptr[areas], void * vaction) {
+        void * areaptr[areas], void * vaction, ismEngine_DelivererContext_t * _delivererContext) {
     char xbuf[12000];
     concat_alloc_t buf = { xbuf, sizeof xbuf, 6 };
     uint32_t proplen = 0;

--- a/server_protocol/src/iotmonitor.c
+++ b/server_protocol/src/iotmonitor.c
@@ -361,7 +361,8 @@ bool reconcileCallback(ismEngine_ConsumerHandle_t hConsumer,
                       ismMessageAreaType_t areaTypes[areaCount],
                       size_t areaLengths[areaCount],
                       void * pAreaData[areaCount],
-                      void * pContext)
+                      void * pContext,
+                      ismEngine_DelivererContext_t * _delivererContext)
 {
     iot_reconcileCallbackContext_t *context = *(iot_reconcileCallbackContext_t **)pContext;
 

--- a/server_protocol/src/jms.c
+++ b/server_protocol/src/jms.c
@@ -358,7 +358,8 @@ static bool replyReceive (
         ismMessageAreaType_t       areatype[areas],
         size_t                     areasize[areas],
         void *                     areaptr[areas],
-        void *                     vaction);
+        void *                     vaction,
+        ismEngine_DelivererContext_t * _delivererContext);
 static void replyRollbackSession(int32_t rc, void * handle, void * vaction);
 static void replyUnsubscribeDurable(int32_t rc, void * handle, void * vaction);
 static void replyUpdateDurable(int32_t rc, void * handle, void * vaction);
@@ -758,8 +759,9 @@ int ism_protocol_selectMessage(
         void *                     areaptr[areas],
         const char *               topic,
         void *                     rule,
-        size_t                     rulelen) {
-    return ism_common_selectMessage(hdr, areas, areatype, areasize, areaptr, topic, rule, rulelen);
+        size_t                     rulelen,
+        ismMessageSelectionLockStrategy_t * lockStrategy) {
+    return ism_common_selectMessage(hdr, areas, areatype, areasize, areaptr, topic, rule, rulelen, lockStrategy);
 }
 
 

--- a/server_protocol/src/jmsreply.c
+++ b/server_protocol/src/jmsreply.c
@@ -1698,7 +1698,8 @@ static bool replyReceive (
         ismMessageAreaType_t       areatype[areas],
         size_t                     areasize[areas],
         void *                     areaptr[areas],
-        void *                     vaction) {
+        void *                     vaction,
+        ismEngine_DelivererContext_t * _delivererContext ) {
     ism_jms_prodcons_t * cons = vaction;
     ism_transport_t * transport = cons->transport;
     jmsProtoObj_t  * pobj = (jmsProtoObj_t*)transport->pobj;

--- a/server_protocol/src/mqtt.c
+++ b/server_protocol/src/mqtt.c
@@ -241,13 +241,14 @@ extern int ism_protocol_selectMessage(
         void *                     areaptr[areas],
         const char *               topic,
         void *                     rule,
-        size_t                     rulelen);
+        size_t                     rulelen,
+        ismMessageSelectionLockStrategy_t * lockStrategy );
 HOT bool ism_mqtt_replyMessage(ismEngine_ConsumerHandle_t consumerh,
         ismEngine_DeliveryHandle_t deliveryh, ismEngine_MessageHandle_t msgh,
         uint32_t seqnum, ismMessageState_t state, uint32_t options,
         ismMessageHeader_t * hdr, uint8_t areas,
         ismMessageAreaType_t areatype[areas], size_t areasize[areas],
-        void * areaptr[areas], void * vaction);
+        void * areaptr[areas], void * vaction, ismEngine_DelivererContext_t * delivererContext);
 static int packetLength(int buflen) ;
 const char * ism_common_getErrorRepl(int which);
 
@@ -6524,7 +6525,7 @@ HOT bool ism_mqtt_replyMessage(ismEngine_ConsumerHandle_t consumerh,
         uint32_t seqnum, ismMessageState_t state, uint32_t options,
         ismMessageHeader_t * hdr, uint8_t areas,
         ismMessageAreaType_t areatype[areas], size_t areasize[areas],
-        void * areaptr[areas], void * vaction) {
+        void * areaptr[areas], void * vaction, ismEngine_DelivererContext_t * delivererContext ) {
     mqtt_prodcons_t * consumer = (mqtt_prodcons_t *) vaction;
     ism_transport_t * transport = consumer->transport;
     mqttProtoObj_t * pobj = (mqttProtoObj_t *) transport->pobj;
@@ -6641,7 +6642,7 @@ HOT bool ism_mqtt_replyMessage(ismEngine_ConsumerHandle_t consumerh,
                 int sellen = BIGINT16(sel+2);
                 memcpy(xbuf, sel+4, sellen);   /* Align the rule */
                 rc = ism_protocol_selectMessage(hdr, areas, areatype, areasize, areaptr,
-                        ftopic.type == VT_String ? ftopic.val.s : NULL, xbuf, sellen);
+                        ftopic.type == VT_String ? ftopic.val.s : NULL, xbuf, sellen, &delivererContext->lockStrategy);
                 if (rc == SELECT_FALSE) {
                     pthread_spin_lock(&pobj->sessionlock);
                     if (deliveryh && pobj->session_handle) {

--- a/server_protocol/src/mqtt.h
+++ b/server_protocol/src/mqtt.h
@@ -371,7 +371,7 @@ extern HOT bool ism_mqtt_replyMessage(ismEngine_ConsumerHandle_t consumerh,
 		ismEngine_DeliveryHandle_t deliveryh, ismEngine_MessageHandle_t  msgh,
         uint32_t seqnum, ismMessageState_t state,
         uint32_t options, ismMessageHeader_t * hdr, uint8_t areas, ismMessageAreaType_t areatype[areas],
-        size_t areasize[areas], void * areaptr[areas], void * vaction);
+        size_t areasize[areas], void * areaptr[areas], void * vaction, ismEngine_DelivererContext_t * delivererContext);
 extern void ism_mqtt_replyClosing(int32_t rc, void * handle, void * vaction);
 extern void ism_mqtt_replyPublish(int32_t rc, void * handle, void * vaction);
 extern void ism_mqtt_replyPutMessage(int32_t rc, void * handle, void * vaction);

--- a/server_protocol/src/plugin.c
+++ b/server_protocol/src/plugin.c
@@ -473,7 +473,7 @@ static bool replyMessage(ismEngine_ConsumerHandle_t consumerh,
         uint32_t seqnum, ismMessageState_t state, uint32_t options,
         ismMessageHeader_t * hdr, uint8_t areas,
         ismMessageAreaType_t areatype[areas], size_t areasize[areas],
-        void * areaptr[areas], void * vaction) {
+        void * areaptr[areas], void * vaction, ismEngine_DelivererContext_t * _delivererContext) {
 
 	char xbuf[12000];
     concat_alloc_t buf = { xbuf, sizeof xbuf, 6 };

--- a/server_protocol/src/protocol.c
+++ b/server_protocol/src/protocol.c
@@ -47,7 +47,8 @@ extern int ism_protocol_selectMessage(
         void *                     areaptr[areas],
         const char *               topic,
         const void *               rule,
-        size_t                     rulelen);
+        size_t                     rulelen,
+        ismMessageSelectionLockStrategy_t * lockStrategy);
 
 static pthread_spinlock_t g_protocol_lock;
 

--- a/server_protocol/src/rmsg.c
+++ b/server_protocol/src/rmsg.c
@@ -229,7 +229,7 @@ bool ism_rmsg_replyMessage(ismEngine_ConsumerHandle_t consumerh,
         uint32_t seqnum, ismMessageState_t state, uint32_t options,
         ismMessageHeader_t * hdr, uint8_t areas,
         ismMessageAreaType_t areatype[areas], size_t areasize[areas],
-        void * areaptr[areas], void * vaction) {
+        void * areaptr[areas], void * vaction, ismEngine_DelivererContext_t * unused) {
     uint32_t proplen = 0;
     uint32_t bodylen = 0;
     char * propp = NULL;

--- a/server_protocol/test/proptest.c
+++ b/server_protocol/test/proptest.c
@@ -151,7 +151,8 @@ extern int ism_protocol_selectMessage(
         void *                     areaptr[areas],
         const char *               topic,
         const void *               rule,
-        size_t                     rulelen);
+        size_t                     rulelen,
+        ismMessageSelectionLockStrategy_t * lockStrategy);
 
 /*
  * Selection test
@@ -182,7 +183,7 @@ void testSelect(void) {
     ism_protocol_putStringValue(&props, "part0/p1/p2");
     areasize[0] = props.used;
     areaptr[0] = props.buf;
-    acl = ism_protocol_findACL("_3", 1);
+    acl = ism_protocol_findACL("_3", 1, NULL);
     ism_protocol_addACLitem(acl, "part1");
     ism_protocol_unlockACL(acl);
 
@@ -208,7 +209,7 @@ void testSelect(void) {
         ism_common_dumpSelectRule(rule, dbuf, sizeof xbuf);
         if (g_verbose)
             printf("\nrule buscon =\n%s\n", dbuf);
-        selected = ism_common_selectMessage(&hdr, 2, areatype, areasize, areaptr, "part0/part1/part2", rule, 0);
+        selected = ism_common_selectMessage(&hdr, 2, areatype, areasize, areaptr, "part0/part1/part2", rule, 0, NULL);
         CU_ASSERT(selected == SELECT_FALSE);
     }
     CU_ASSERT(rc == 0);
@@ -219,7 +220,7 @@ void testSelect(void) {
         printf("\nrule 1 =%s\n", dbuf);
     CU_ASSERT(rc == 0);
     if (rc == 0) {
-        selected = ism_protocol_selectMessage(&hdr, 2, areatype, areasize, areaptr, NULL, rule, 0);
+        selected = ism_protocol_selectMessage(&hdr, 2, areatype, areasize, areaptr, NULL, rule, 0, NULL);
         CU_ASSERT(selected == SELECT_TRUE);
     }
     if (rule)
@@ -228,7 +229,7 @@ void testSelect(void) {
     rc = ism_common_compileSelectRule(&rule, &rulelen, "sam = 'fred'");
     CU_ASSERT(rc == 0);
     if (rc == 0) {
-        selected = ism_protocol_selectMessage(&hdr, 2, areatype, areasize, areaptr, NULL, rule, 0);
+        selected = ism_protocol_selectMessage(&hdr, 2, areatype, areasize, areaptr, NULL, rule, 0, NULL);
         CU_ASSERT(selected == SELECT_TRUE);
     }
     if (rule)
@@ -237,7 +238,7 @@ void testSelect(void) {
     rc = ism_common_compileSelectRule(&rule, &rulelen, "int = 33");
     CU_ASSERT(rc == 0);
     if (rc == 0) {
-        selected = ism_protocol_selectMessage(&hdr, 2, areatype, areasize, areaptr, NULL, rule, 0);
+        selected = ism_protocol_selectMessage(&hdr, 2, areatype, areasize, areaptr, NULL, rule, 0, NULL);
         CU_ASSERT(selected == SELECT_TRUE);
     }
     if (rule)
@@ -246,7 +247,7 @@ void testSelect(void) {
     rc = ism_common_compileSelectRule(&rule, &rulelen, "JMS_IBM_Retain = 0");
     CU_ASSERT(rc == 0);
     if (rc == 0) {
-        selected = ism_protocol_selectMessage(&hdr, 2, areatype, areasize, areaptr, NULL, rule, 0);
+        selected = ism_protocol_selectMessage(&hdr, 2, areatype, areasize, areaptr, NULL, rule, 0, NULL);
         CU_ASSERT(selected == SELECT_TRUE);
     }
     if (rule)
@@ -255,7 +256,7 @@ void testSelect(void) {
     rc = ism_common_compileSelectRule(&rule, &rulelen, "garbage = 999");
     CU_ASSERT(rc == 0);
     if (rc == 0) {
-        selected = ism_protocol_selectMessage(&hdr, 2, areatype, areasize, areaptr, NULL, rule, 0);
+        selected = ism_protocol_selectMessage(&hdr, 2, areatype, areasize, areaptr, NULL, rule, 0, NULL);
         CU_ASSERT(selected == SELECT_UNKNOWN);
     }
     if (rule)
@@ -264,7 +265,7 @@ void testSelect(void) {
     rc = ism_common_compileSelectRule(&rule, &rulelen, "garbage = junk");
     CU_ASSERT(rc == 0);
     if (rc == 0) {
-        selected = ism_protocol_selectMessage(&hdr, 2, areatype, areasize, areaptr, NULL, rule, 0);
+        selected = ism_protocol_selectMessage(&hdr, 2, areatype, areasize, areaptr, NULL, rule, 0, NULL);
         CU_ASSERT(selected == SELECT_UNKNOWN);
     }
     if (rule)
@@ -273,7 +274,7 @@ void testSelect(void) {
     rc = ism_common_compileSelectRuleOpt(&rule, &rulelen, "Topic = 'part0/p1/p2'", 1);
     CU_ASSERT(rc == 0);
     if (rc == 0) {
-        selected = ism_protocol_selectMessage(&hdr, 2, areatype, areasize, areaptr, NULL, rule, 0);
+        selected = ism_protocol_selectMessage(&hdr, 2, areatype, areasize, areaptr, NULL, rule, 0, NULL);
         CU_ASSERT(selected == SELECT_TRUE);
     }
     if (rule)
@@ -282,7 +283,7 @@ void testSelect(void) {
     rc = ism_common_compileSelectRuleOpt(&rule, &rulelen, "Topic = 'p0/part1/part2'", 1);
     CU_ASSERT(rc == 0);
     if (rc == 0) {
-        selected = ism_protocol_selectMessage(&hdr, 2, areatype, areasize, areaptr, "p0/part1/part2", rule, 0);
+        selected = ism_protocol_selectMessage(&hdr, 2, areatype, areasize, areaptr, "p0/part1/part2", rule, 0, NULL);
         CU_ASSERT(selected == SELECT_TRUE);
     }
     if (rule)
@@ -293,7 +294,7 @@ void testSelect(void) {
     if (rc == 0) {
         // ism_common_dumpSelectRule(rule, dbuf, sizeof xbuf);
         // printf("qos=%s\n", dbuf);
-        selected = ism_protocol_selectMessage(&hdr, 2, areatype, areasize, areaptr, NULL, rule, 0);
+        selected = ism_protocol_selectMessage(&hdr, 2, areatype, areasize, areaptr, NULL, rule, 0, NULL);
         CU_ASSERT(selected == SELECT_TRUE);
     }
     if (rule)
@@ -304,7 +305,7 @@ void testSelect(void) {
     if (rc == 0) {
         // ism_common_dumpSelectRule(rule, dbuf, sizeof xbuf);
         // printf("topicpart=%s\n", dbuf);
-        selected = ism_protocol_selectMessage(&hdr, 2, areatype, areasize, areaptr, "p0/part1/part2", rule, 0);
+        selected = ism_protocol_selectMessage(&hdr, 2, areatype, areasize, areaptr, "p0/part1/part2", rule, 0, NULL);
         CU_ASSERT(selected == SELECT_TRUE);
     }
     if (rule)
@@ -314,7 +315,7 @@ void testSelect(void) {
     rc = ism_common_compileSelectRule(&rule, &rulelen, "JMS_IBM_Retain = 1");
     CU_ASSERT(rc == 0);
     if (rc == 0) {
-        selected = ism_protocol_selectMessage(&hdr, 2, areatype, areasize, areaptr, NULL, rule, 0);
+        selected = ism_protocol_selectMessage(&hdr, 2, areatype, areasize, areaptr, NULL, rule, 0, NULL);
         CU_ASSERT(selected == SELECT_TRUE);
     }
     if (rule)
@@ -350,7 +351,7 @@ void testACLCheck(void) {
         ism_common_dumpSelectRule(rule, zbuf, sizeof zbuf);
         if (g_verbose)
             printf("\n%s\n", zbuf);
-        selected = ism_protocol_selectMessage(&hdr, 2, areatype, areasize, areaptr, NULL, rule, 0);
+        selected = ism_protocol_selectMessage(&hdr, 2, areatype, areasize, areaptr, NULL, rule, 0, NULL);
         CU_ASSERT(selected == SELECT_TRUE);
     }
 }

--- a/server_protocol/test/test_iotmonitor.c
+++ b/server_protocol/test/test_iotmonitor.c
@@ -435,7 +435,8 @@ int32_t ism_engine_getRetainedMessageAPI_CB(ismEngine_SessionHandle_t hSession,
                                                      areaTypes,
                                                      areaLengths,
                                                      areaData,
-                                                     pMessageContext);
+                                                     pMessageContext,
+                                                     NULL);
                 }
             }
         }

--- a/server_proxy/src/iotrest.c
+++ b/server_proxy/src/iotrest.c
@@ -777,7 +777,7 @@ static int httpFindACL(ism_transport_t * transport) {
 	char xbuf [2048];
 	concat_alloc_t buf = {xbuf, sizeof xbuf, 19};
 	const char * aclKey = ism_proxy_getACLKey(transport);
-	ism_acl_t * acl = ism_protocol_findACL(aclKey, 0);
+	ism_acl_t * acl = ism_protocol_findACL(aclKey, 0, NULL);
 
 	xbuf[16] = 0;
     xbuf[17] = 1;
@@ -1056,7 +1056,7 @@ static int httpPublish(ism_http_t * http, int sendDataNow) {
 		        key[dtLen] = '/';
 		        memcpy(key+dtLen+1, devId, idLen+1);
 		        aclKey = ism_proxy_getACLKey(transport);
-		        rcCheckACL = ism_protocol_checkACL(key, aclKey);
+		        rcCheckACL = ism_protocol_checkACL(key, aclKey, NULL);
 				if (rcCheckACL != 0) {
 					rcCheckACL = ISMRC_NotAuthorized;
 					TRACEL(6, transport->trclevel, "httpPublish: ACL check failed connect=%u user=%s client=%s devType=%s devId=%s subprot=%d, rcCheckACL=%d\n",
@@ -2333,7 +2333,7 @@ void ism_iotmsg_doneConnection(int32_t rc, ism_transport_t * transport) {
     /* Remove transport from ACL */
     if(transport->has_acl){
 		const char * aclKey = ism_proxy_getACLKey(transport);
-		ism_acl_t * acl = ism_protocol_findACL(aclKey, 0);
+		ism_acl_t * acl = ism_protocol_findACL(aclKey, 0, NULL);
 		if (acl) {
 			TRACEL(8, transport->trclevel, "Remove connection from ACL: connect=%u name=%s rc=%u was=%p\n",
 					transport->index, aclKey, rc, acl->object);

--- a/server_proxy/src/javaconfig.c
+++ b/server_proxy/src/javaconfig.c
@@ -408,26 +408,26 @@ void ism_proxy_changeMsgRouting(ism_tenant_t * tenant, int old_msgRouting) {
     ism_acl_t * acl;
 
     if (msgroute & FILTER_UNRELIABLE) {
-        acl = ism_protocol_findACL("_0", 1);
+        acl = ism_protocol_findACL("_0", 1, NULL);
         ism_protocol_addACLitem(acl, tenant->name);
         ism_protocol_unlockACL(acl);
         updateACL(tenant, 0, 1);
     } else {
         if (old_msgRouting & FILTER_UNRELIABLE) {
-            acl = ism_protocol_findACL("_0", 1);
+            acl = ism_protocol_findACL("_0", 1, NULL);
             ism_protocol_delACLitem(acl, tenant->name);
             ism_protocol_unlockACL(acl);
             updateACL(tenant, 0, 0);
         }
     }
     if (msgroute & FILTER_RELIABLE) {
-        acl = ism_protocol_findACL("_1", 1);
+        acl = ism_protocol_findACL("_1", 1, NULL);
         ism_protocol_addACLitem(acl, tenant->name);
         ism_protocol_unlockACL(acl);
         updateACL(tenant, 1, 1);
     } else {
         if (old_msgRouting & FILTER_RELIABLE) {
-            acl = ism_protocol_findACL("_1", 1);
+            acl = ism_protocol_findACL("_1", 1, NULL);
             ism_protocol_delACLitem(acl, tenant->name);
             ism_protocol_unlockACL(acl);
             updateACL(tenant, 1, 0);
@@ -507,7 +507,7 @@ void ism_proxy_sendAllACLs(const char * aclsrc, int acllen) {
         case '!':
             {
                 concat_alloc_t buf = {xbuf, sizeof xbuf, 19};
-                ism_acl_t * acl = ism_protocol_findACL(ap+1, 0);
+                ism_acl_t * acl = ism_protocol_findACL(ap+1, 0, NULL);
                 if (acl) {
                     if (acl->object) {
                         ism_transport_t * transport = (ism_transport_t *)acl->object;

--- a/server_proxy/src/monitor.c
+++ b/server_proxy/src/monitor.c
@@ -522,7 +522,7 @@ static void sendGlobalACL(ism_transport_t * transport) {
     xbuf[18] = EXIV_EndExtension;
     for (i=0; i<9; i++) {
         aclname[1] = i+'0';
-        acl = ism_protocol_findACL(aclname, 0);
+        acl = ism_protocol_findACL(aclname, 0, NULL);
         if (acl) {
             found = 1;
             ism_protocol_getACL(&buf, acl);

--- a/server_proxy/src/pxhttp.c
+++ b/server_proxy/src/pxhttp.c
@@ -286,7 +286,7 @@ static int sendACLs(ism_transport_t * transport) {
     xbuf[17] = 1;
     xbuf[18] = EXIV_EndExtension;
     aclKey = ism_proxy_getACLKey(transport);
-    acl = ism_protocol_findACL(aclKey, 0);
+    acl = ism_protocol_findACL(aclKey, 0, NULL);
     if (acl) {
         ism_protocol_getACL(&buf, acl);
         ism_protocol_unlockACL(acl);
@@ -379,7 +379,7 @@ int ism_hout_receive(ism_transport_t * transport, char * inbuf, int buflen, int 
                 if (ctransport && ctransport->has_acl) {
                 	const char * aclKey = ism_proxy_getACLKey(ctransport);
                     TRACE(6, "Send ACL to the server: %s\n", aclKey);
-                    ism_acl_t * acl = ism_protocol_findACL(aclKey, 0);
+                    ism_acl_t * acl = ism_protocol_findACL(aclKey, 0, NULL);
                     if (acl) {
                         TRACE(8, "Send ACL to server: connect=%u name=%s was=%p\n",
                                 transport->index, aclKey, acl->object);

--- a/server_proxy/src/pxmhub.c
+++ b/server_proxy/src/pxmhub.c
@@ -126,7 +126,7 @@ int ism_mhub_message_produce(ism_transport_t * transport, ism_mhub_t * mhub, mhu
         kafka_produce_msg_t * msgs, int * producedMsgsCount, int isResend);
 static kafka_produce_msg_t *  checkMHubEventBatch(ism_mhub_t * mhub, mhub_part_t * mhub_part, ism_time_t now, int closing) ;
 static int mhubPartitionProduceTimer(ism_timer_t timer, ism_time_t timestamp, void * userdata) ;
-int ism_mqtt_propgen(ism_prop_t * xprops, ism_emsg_t * emsg, const char * name, ism_field_t * f, void * extra);
+int ism_mqtt_propgen(ism_prop_t * xprops, ism_emsg_t * emsg, const char * name, ism_field_t * f, void * extra, ismMessageSelectionLockStrategy_t * lockStrategy);
 static int needMHubBatch(ism_mhub_t * mhub, mhub_part_t * mhub_part, ism_time_t now);
 static int  mhubProduceJob(ism_transport_t * transport, void * param1, uint64_t param2);
 static int addMhub(ism_mhub_t * mhub);
@@ -1385,7 +1385,7 @@ int ism_mhub_selectMessages(ism_mhub_t * mhub, uint16_t * topicix, int count, co
                         emsg.topic = topic = alloca(strlen(pmsg->topic) + 1);
                         memcpy(topic, pmsg->topic, pmsg->topic_len);
                         topic[pmsg->topic_len] = 0;
-                        selected = ism_common_filter((ismRule_t *)(rp+3), mhub->props, ism_mqtt_propgen, &emsg) == SELECT_TRUE;
+                        selected = ism_common_filter((ismRule_t *)(rp+3), mhub->props, ism_mqtt_propgen, &emsg, NULL) == SELECT_TRUE;
                     }
                     rp += rulelen + 3;    /* Two byte rule len but no trailing null */
                     break;

--- a/server_proxy/src/pxmqtt.c
+++ b/server_proxy/src/pxmqtt.c
@@ -894,7 +894,7 @@ static int checkACL(ism_transport_t * transport, const char * mtopic) {
         key[dtlen] = '/';
         memcpy(key+dtlen+1, devid, idlen+1);
         aclKey = ism_proxy_getACLKey(transport);
-        aclfound = ism_protocol_checkACL(key, aclKey);
+        aclfound = ism_protocol_checkACL(key, aclKey, NULL);
     }
     if (aclfound == 1) {
         return ISMRC_NotAuthorized;
@@ -2090,7 +2090,7 @@ int checkSubs(const char * subs, int sublen, ism_transport_t * stransport, ism_t
             /* We might not yet have checked if we have ACLs */
             if (transport->has_acl == 2) {
                 const char * aclKey = ism_proxy_getACLKey(transport);
-                ism_acl_t * acl = ism_protocol_findACL(aclKey, 0);
+                ism_acl_t * acl = ism_protocol_findACL(aclKey, 0, NULL);
                 if (acl) {
                     ism_protocol_unlockACL(acl);
                     transport->has_acl = 1;
@@ -2708,7 +2708,7 @@ int ism_mqtt_receive(ism_transport_t * transport, char * inbuf, int buflen, int 
                 if (ctransport->has_acl) {
                     const char * aclKey = ism_proxy_getACLKey(ctransport);
                     TRACE(6, "Send ACL to the server connect=%u acl=%s\n", transport->index, aclKey);
-                    ism_acl_t * acl = ism_protocol_findACL(aclKey, 0);
+                    ism_acl_t * acl = ism_protocol_findACL(aclKey, 0, NULL);
                     if (acl) {
                         TRACE(8, "Add transport to ACL: connect=%u name=%s was=%p\n",
                                 transport->index, aclKey, acl->object);
@@ -3149,7 +3149,7 @@ static int sendACLs(ism_transport_t * transport) {
     xbuf[18] = EXIV_EndExtension;
     
     aclKey = ism_proxy_getACLKey(transport);
-    acl = ism_protocol_findACL(aclKey, 0);
+    acl = ism_protocol_findACL(aclKey, 0, NULL);
     if (acl) {
         ism_protocol_getACL(&buf, acl);
         ism_protocol_unlockACL(acl);
@@ -6012,7 +6012,7 @@ void ism_mqtt_doneConnection(ism_transport_t * transport) {
 	    /* Remove transport from ACL */
 		if(transport->has_acl){
 			const char * aclKey = ism_proxy_getACLKey(transport);;
-			ism_acl_t * acl = ism_protocol_findACL(aclKey, 0);
+			ism_acl_t * acl = ism_protocol_findACL(aclKey, 0, NULL);
 			if (acl) {
 				TRACE(8, "Remove connection from ACL: connect=%u client=%s rc=%u was=%p\n",
 						transport->index, aclKey, rc, acl->object);
@@ -7531,7 +7531,7 @@ int ism_mqtt_mpropSet(mqtt_prop_ctx_t * ctx, void * userdata, mqtt_prop_field_t 
 /*
  * Generate properties from the message
  */
-int ism_mqtt_propgen(ism_prop_t * xprops, ism_emsg_t * emsg, const char * name, ism_field_t * f, void * extra) {
+int ism_mqtt_propgen(ism_prop_t * xprops, ism_emsg_t * emsg, const char * name, ism_field_t * f, void * extra, ismMessageSelectionLockStrategy_t * lockStrategy) {
     if (emsg->otherprop_len > 0) {
         ism_common_checkMqttPropFields((char *)emsg->otherprops, emsg->otherprop_len, g_ctx5, 0xFFFF, ism_mqtt_mpropSet, xprops);
         emsg->otherprop_len = 0;

--- a/server_proxy/src/pxrouting.c
+++ b/server_proxy/src/pxrouting.c
@@ -898,7 +898,7 @@ static int messageRoutingInternal(ism_transport_t * transport, const char * buf,
 			areasize[0] = props.used;
 			areaptr[0] = props.buf;
 
-			selected = ism_common_selectMessage(&hdr, 2, areatype, areasize, areaptr, (const char*)topic, routeRule->selector, 0);
+			selected = ism_common_selectMessage(&hdr, 2, areatype, areasize, areaptr, (const char*)topic, routeRule->selector, 0, NULL);
 			TRACE(7, "ism_route_routeMessage: Selection topic=%s qos=%d selected=%d\n", topic, qos, selected );
 			if(selected==SELECT_TRUE){
 				rulesMatched++;
@@ -1216,7 +1216,7 @@ int ism_route_routeMessage(ism_transport_t * transport, const char * buf, int bu
 			ism_routing_route_t * route = g_internalKafkaRoute;
 
 			if(g_IMMessagingSelector != NULL){
-				selected = ism_common_selectMessage(&hdr, 2, areatype, areasize, areaptr, (const char*)topic, g_IMMessagingSelector, 0);
+				selected = ism_common_selectMessage(&hdr, 2, areatype, areasize, areaptr, (const char*)topic, g_IMMessagingSelector, 0, NULL);
 			}else{
 				selected = SELECT_TRUE;
 			}

--- a/server_proxy/test/pxrouting_test.c
+++ b/server_proxy/test/pxrouting_test.c
@@ -218,7 +218,7 @@ void pxrouting_test_parseRouteRuleOnly(void){
 		int totalRun=1;
 		for (cindex=0; cindex < totalRun; cindex++){
 			ism_time_t beginTime = ism_common_currentTimeNanos();
-			selected = ism_common_selectMessage(&hdr, 2, areatype, areasize, areaptr, topic, routeRule->selector, 0);
+			selected = ism_common_selectMessage(&hdr, 2, areatype, areasize, areaptr, topic, routeRule->selector, 0, NULL);
 			ism_time_t endTime = ism_common_currentTimeNanos();
 			elapsed = (endTime-beginTime);
 			total+=elapsed;
@@ -284,7 +284,7 @@ void pxrouting_test_parseRouteRuleOnlyFalseSelection(void){
 		int totalRun=1;
 		for (cindex=0; cindex < totalRun; cindex++){
 			ism_time_t beginTime = ism_common_currentTimeNanos();
-			selected = ism_common_selectMessage(&hdr, 2, areatype, areasize, areaptr, topic, routeRule->selector, 0);
+			selected = ism_common_selectMessage(&hdr, 2, areatype, areasize, areaptr, topic, routeRule->selector, 0, NULL);
 			ism_time_t endTime = ism_common_currentTimeNanos();
 			elapsed = (endTime-beginTime);
 			total+=elapsed;

--- a/server_proxy_br/src/bridge.c
+++ b/server_proxy_br/src/bridge.c
@@ -322,7 +322,7 @@ int ism_bridge_getConnectionList(const char * match, ism_json_t * jobj, int json
 void ism_bridge_getConnectionJson(ism_json_t * jobj, ism_connection_t * connection, const char * name);
 static void completeQoS2NotPresent(ism_transport_t * transport);
 static void completeQoS2Present(ism_transport_t * transport, ism_transport_t * dtransport);
-int ism_mqtt_propgen(ism_prop_t * xprops, ism_emsg_t * emsg, const char * name, ism_field_t * f, void * extra);
+int ism_mqtt_propgen(ism_prop_t * xprops, ism_emsg_t * emsg, const char * name, ism_field_t * f, void * extra, ismMessageSelectionLockStrategy_t * lockStrategy );
 extern void ism_protocol_ensureBuffer(concat_alloc_t * buf, int len);
 int  ism_tenant_createObfus(const char * user, const char * pw, char * buf, int buflen, int otype);
 const char * ism_transport_makepw(const char * data, char * buf, int len, int dir);
@@ -1497,7 +1497,7 @@ int selectMsg(ism_forwarder_t * forwarder, mqttbrMsg_t * mmsg) {
     emsg.otherprops = (char *)mmsg->props;
     emsg.proplen = mmsg->prop_len;
     emsg.topic = mmsg->topic;
-    selected = ism_common_filter(forwarder->selector, forwarder->props, ism_mqtt_propgen, &emsg);
+    selected = ism_common_filter(forwarder->selector, forwarder->props, ism_mqtt_propgen, &emsg, NULL);
     pthread_spin_unlock(&forwarder->lock);
     return selected;
 }

--- a/server_proxy_br/test/bridge_test.c
+++ b/server_proxy_br/test/bridge_test.c
@@ -209,19 +209,19 @@ void propgenTest(void) {
     emsg.otherprop_len = buf.used;
     f.type = VT_Integer;
 
-    rc = ism_mqtt_propgen(props, &emsg, "another", &f, NULL);
+    rc = ism_mqtt_propgen(props, &emsg, "another", &f, NULL, NULL);
     CU_ASSERT(rc == 1);
     CU_ASSERT(f.type == VT_Null);
 
-    rc = ism_mqtt_propgen(props, &emsg, "_ContentType", &f, NULL);
+    rc = ism_mqtt_propgen(props, &emsg, "_ContentType", &f, NULL, NULL);
     CU_ASSERT(rc == 1);
     CU_ASSERT(f.type == VT_Null);
 
-    rc = ism_mqtt_propgen(props, &emsg, "_ReplyTo", &f, NULL);
+    rc = ism_mqtt_propgen(props, &emsg, "_ReplyTo", &f, NULL, NULL);
     CU_ASSERT(rc == 1);
     CU_ASSERT(f.type == VT_Null);
 
-    rc = ism_mqtt_propgen(props, &emsg, "_Correlation", &f, NULL);
+    rc = ism_mqtt_propgen(props, &emsg, "_Correlation", &f, NULL, NULL);
     CU_ASSERT(rc == 1);
     CU_ASSERT(f.type == VT_Null);
 
@@ -231,33 +231,33 @@ void propgenTest(void) {
     ism_common_putMqttPropNamePair(&buf, MPI_UserProperty, g_ctx5, "another", -1, "anotherval", -1);
     ism_common_putMqttPropField(&buf, MPI_TopicAlias, g_ctx5, 456);
 
-    rc = ism_mqtt_propgen(props, &emsg, "another", &f, NULL);
+    rc = ism_mqtt_propgen(props, &emsg, "another", &f, NULL, NULL);
     CU_ASSERT(rc == 1);
     CU_ASSERT(f.type == VT_Null);
 
     emsg.otherprop_len = buf.used;
     ism_common_clearProperties(props);
-    rc = ism_mqtt_propgen(props, &emsg, "prop1", &f, NULL);
+    rc = ism_mqtt_propgen(props, &emsg, "prop1", &f, NULL, NULL);
     CU_ASSERT(rc == 0);
     CU_ASSERT(f.type == VT_String);
     CU_ASSERT(f.val.s && !strcmp(f.val.s, "val2"));
 
-    rc = ism_mqtt_propgen(props, &emsg, "_ContentType", &f, NULL);
+    rc = ism_mqtt_propgen(props, &emsg, "_ContentType", &f, NULL, NULL);
     CU_ASSERT(rc == 0);
     CU_ASSERT(f.type == VT_String);
     CU_ASSERT(f.val.s && !strcmp(f.val.s, "fred"));
 
-    rc = ism_mqtt_propgen(props, &emsg, "_Correlation", &f, NULL);
+    rc = ism_mqtt_propgen(props, &emsg, "_Correlation", &f, NULL, NULL);
     CU_ASSERT(rc == 0);
     CU_ASSERT(f.type == VT_String);
     CU_ASSERT(f.val.s && !strcmp(f.val.s, "abcd"));
 
-    rc = ism_mqtt_propgen(props, &emsg, "_ReplyTo", &f, NULL);
+    rc = ism_mqtt_propgen(props, &emsg, "_ReplyTo", &f, NULL, NULL);
     CU_ASSERT(rc == 0);
     CU_ASSERT(f.type == VT_String);
     CU_ASSERT(f.val.s && !strcmp(f.val.s, "output/topic"));
 
-    rc = ism_mqtt_propgen(props, &emsg, "another", &f, NULL);
+    rc = ism_mqtt_propgen(props, &emsg, "another", &f, NULL, NULL);
     CU_ASSERT(rc == 0);
     CU_ASSERT(f.type == VT_String);
     CU_ASSERT(f.val.s && !strcmp(f.val.s, "anotherval"));
@@ -268,11 +268,11 @@ void propgenTest(void) {
     emsg.otherprop_len = buf.used;
     ism_common_clearProperties(props);
 
-    rc = ism_mqtt_propgen(props, &emsg, "_Correlation", &f, NULL);
+    rc = ism_mqtt_propgen(props, &emsg, "_Correlation", &f, NULL, NULL);
     CU_ASSERT(rc == 1);
     CU_ASSERT(f.type == VT_Null);
 
-    rc = ism_mqtt_propgen(props, &emsg, "prop1", &f, NULL);
+    rc = ism_mqtt_propgen(props, &emsg, "prop1", &f, NULL, NULL);
     CU_ASSERT(rc == 0);
     CU_ASSERT(f.type == VT_String);
     CU_ASSERT(f.val.s && !strcmp(f.val.s, "val2"));

--- a/server_utils/Makefile
+++ b/server_utils/Makefile
@@ -97,7 +97,7 @@ libismutil-FILES = execinfo.c      \
 CUNITFILES = testUtilCUnit.c testTLS.c testProtoex.c testTimerCUnit.c \
     testLoggingCUnit.c testLinkedListCUnit.c testHashMapCUnit.c testArrayCUnit.c testTracingCUnit.c \
     testTimeUtilsCUnit.c testUtilsOtherFuncsCUnit.c testGlobalCUnit.c testDelayCUnit.c testBufferPoolCUnit.c \
-    test_utils_file.c test_utils_log.c testUtilsMemHandlerCUnit.c testSASLScram.c
+    test_utils_file.c test_utils_log.c testUtilsMemHandlerCUnit.c testSASLScram.c testFilterCUnit.c
 
 LIB-TARGETS += $(LIBDIR)/libismutil$(SO)
 $(LIBDIR)/libismutil$(SO): $(call objects, $(libismutil-FILES))

--- a/server_utils/include/ismmessage.h
+++ b/server_utils/include/ismmessage.h
@@ -43,6 +43,23 @@ typedef struct
     uint8_t  MessageType;     ///< Message type - MTYPE_*
 } ismMessageHeader_t;
 
+/***********************************************************************************/
+/*                                                                                 */
+/* Lock Strategy to allow read locks to be held across multiple callS              */
+/*                                                                                 */
+/* no_lock_held - lock is currently not held                                       */
+/* read_lock_held - holding read lock will not be released by standard unlock call */
+/* write_lock_held - holding write lock                                            */
+/* dont_persist_lock - lock will not persist when unlocked                         */
+/*                                                                                 */
+/***********************************************************************************/
+enum lockStrategy_e {LS_NO_LOCK_HELD , LS_READ_LOCK_HELD , LS_WRITE_LOCK_HELD , LS_DONT_PERSIST_LOCK };
+typedef struct
+{ 
+    enum lockStrategy_e rlac;
+    uint32_t lock_persisted_counter;
+    uint32_t lock_dropped_counter;
+} ismMessageSelectionLockStrategy_t;
 
 //
 // Message persistence

--- a/server_utils/include/selector.h
+++ b/server_utils/include/selector.h
@@ -169,7 +169,8 @@ XAPI int ism_common_selectMessage(
         void *                     areaptr[areas],
         const char *               topic,
         void *                     rule,
-        size_t                     rulelen);
+        size_t                     rulelen,
+        ismMessageSelectionLockStrategy_t * lockStrategy);
 
 /**
  * Compute the length of the match string.
@@ -211,7 +212,7 @@ typedef struct ism_acl_t {
  * @param  aclname The name of the ACL
  * @return 0=found, 1=not-found, -1=no-ACL
  */
-XAPI int ism_protocol_checkACL(const char * key, const char * aclname);
+XAPI int ism_protocol_checkACL(const char * key, const char * aclname, ismMessageSelectionLockStrategy_t * lockStrategy);
 
 /*
  * Find the ACL and create it if requested.
@@ -219,7 +220,7 @@ XAPI int ism_protocol_checkACL(const char * key, const char * aclname);
  * @param create If non-zero, create the ACL if it does not exist
  * @return The locked ACL or NULL
  */
-XAPI ism_acl_t * ism_protocol_findACL(const char * name, int create);
+XAPI ism_acl_t * ism_protocol_findACL(const char * name, int create, ismMessageSelectionLockStrategy_t * lockStrategy);
 
 /*
  * Complete the handling of an ACL
@@ -227,6 +228,8 @@ XAPI ism_acl_t * ism_protocol_findACL(const char * name, int create);
  * @param acl  The ACL
  */
 XAPI void ism_protocol_unlockACL(ism_acl_t * acl);
+
+XAPI void ism_common_unlockACLList( void ); 
 
 /*
  * Add an item to an ACL set.
@@ -310,7 +313,7 @@ XAPI int ism_protocol_getACL(concat_alloc_t * buf, ism_acl_t * acl);
  * @param extra    A field with additional data.  This is based on the name to generate
  */
 typedef int (* property_gen_t)(ism_prop_t * props, ism_emsg_t * emsg, const char * name,
-        ism_field_t * field, void * extra);
+        ism_field_t * field, void * extra, ismMessageSelectionLockStrategy_t * lockStrategy);
 
 /*
  * Do message selection.
@@ -323,7 +326,8 @@ typedef int (* property_gen_t)(ism_prop_t * props, ism_emsg_t * emsg, const char
  * @param emsg    Data for the properties generator
  *
  */
-XAPI int ism_common_filter(ismRule_t * rule, ism_prop_t * props, property_gen_t generator, ism_emsg_t * emsg);
+XAPI int ism_common_filter(ismRule_t * rule, ism_prop_t * props, property_gen_t generator, ism_emsg_t * emsg, ismMessageSelectionLockStrategy_t * lockStrategy);
+
 
 
 

--- a/server_utils/test/testFilterCUnit.c
+++ b/server_utils/test/testFilterCUnit.c
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2012-2021 Contributors to the Eclipse Foundation
+ * 
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/*
+ * File: testFilterCUnit.c
+ * Component: server
+ * SubComponent: server_utils
+ *
+ * Created on:
+ *     Author:
+ * --------------------------------------------------------------
+ *
+ *
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#include <ismutil.h>
+#include <ismuints.h>
+#include "testFilterCUnit.h"
+
+//defined in ismutil.c
+void ism_common_initUtil2(int type);
+
+/**
+ * Perform initialization for filter test suite.
+ */
+int initFilterCUnitSuite(void){
+    return 0;
+}
+
+/**
+ * Clean up after filter test suite is executed.
+ */
+int cleanFilterCUnitSuite(void){
+    return 0;
+}
+
+#define NULL_PTR ((void**)0)
+static void CUnit_acl_readlock_test(void) {
+    ism_common_initUtil2(2);
+    ism_protocol_lockACLList(false,NULL);
+    int wlocked = ism_common_tryWriteLockACLList( );
+    CU_ASSERT(wlocked != 0);
+    int rlocked = ism_common_tryReadLockACLList( );
+    CU_ASSERT(rlocked == 0);
+    ism_common_unlockACLList(); 
+    ism_common_unlockACLList(); 
+}
+
+static void CUnit_acl_writelock_test(void) {
+    ism_common_initUtil2(2);
+    ism_protocol_lockACLList(true,NULL);
+    int wlocked = ism_common_tryWriteLockACLList( );
+    CU_ASSERT(wlocked != 0);
+    int rlocked = ism_common_tryReadLockACLList( );
+    CU_ASSERT(rlocked != 0);
+    ism_common_unlockACLList(); 
+}
+
+static void CUint_acl_notPersist_test(void) {
+    ism_common_initUtil2(2);
+    ismMessageSelectionLockStrategy_t locks;
+    locks.rlac = LS_DONT_PERSIST_LOCK;
+    ism_protocol_lockACLList(false,&locks);
+    CU_ASSERT(locks.rlac == LS_DONT_PERSIST_LOCK);
+    int wlocked = ism_common_tryWriteLockACLList( );
+    CU_ASSERT(wlocked != 0);
+    ism_protocol_unlockACLList(&locks);
+    CU_ASSERT(locks.rlac == LS_DONT_PERSIST_LOCK);
+    wlocked = ism_common_tryWriteLockACLList( );
+    CU_ASSERT(wlocked == 0);
+    ism_common_unlockACLList(); 
+}
+
+static void CUint_acl_persistRead_test(void) {
+    ism_common_initUtil2(2);
+    ismMessageSelectionLockStrategy_t locks;
+    locks.rlac = LS_NO_LOCK_HELD;
+    ism_protocol_lockACLList(false,&locks);
+    CU_ASSERT(locks.rlac == LS_READ_LOCK_HELD);
+    int wlocked = ism_common_tryWriteLockACLList( );
+    CU_ASSERT(wlocked != 0);
+    int rlocked = ism_common_tryReadLockACLList( );
+    CU_ASSERT(rlocked == 0);
+    ism_common_unlockACLList();
+    ism_protocol_unlockACLList(&locks);
+    CU_ASSERT(locks.rlac == LS_READ_LOCK_HELD);
+    wlocked = ism_common_tryWriteLockACLList( );
+    CU_ASSERT(wlocked != 0);
+    rlocked = ism_common_tryReadLockACLList( );
+    CU_ASSERT(rlocked == 0);
+    ism_common_unlockACLList();
+    ism_common_unlockACLList(); 
+}
+
+static void CUint_acl_dontPersistWrite_test(void) {
+    ism_common_initUtil2(2);
+    ismMessageSelectionLockStrategy_t locks;
+    locks.rlac = LS_NO_LOCK_HELD;
+    ism_protocol_lockACLList(true,&locks);
+    CU_ASSERT(locks.rlac == LS_WRITE_LOCK_HELD);
+    int wlocked = ism_common_tryWriteLockACLList( );
+    CU_ASSERT(wlocked != 0);
+    int rlocked = ism_common_tryReadLockACLList( );
+    CU_ASSERT(rlocked != 0);
+
+    ism_protocol_unlockACLList(&locks);
+    CU_ASSERT(locks.rlac == LS_NO_LOCK_HELD);
+    wlocked = ism_common_tryWriteLockACLList( );
+    CU_ASSERT(wlocked == 0);
+    ism_common_unlockACLList(); 
+}
+
+static void CUint_acl_upgradeReadLock_test(void) {
+    ism_common_initUtil2(2);
+
+    //Take read lock and persist
+    ismMessageSelectionLockStrategy_t locks;
+    locks.rlac = LS_NO_LOCK_HELD;
+    ism_protocol_lockACLList(false,&locks);
+    CU_ASSERT(locks.rlac == LS_READ_LOCK_HELD);
+    int wlocked = ism_common_tryWriteLockACLList( );
+    CU_ASSERT(wlocked != 0);
+    int rlocked = ism_common_tryReadLockACLList( );
+    CU_ASSERT(rlocked == 0);
+    ism_common_unlockACLList(); 
+
+    //check it persists
+    CU_ASSERT(locks.rlac == LS_READ_LOCK_HELD);
+    wlocked = ism_common_tryWriteLockACLList( );
+    CU_ASSERT(wlocked != 0);
+
+    //upgrade to write lock
+    ism_protocol_lockACLList(true,&locks);
+    CU_ASSERT(locks.rlac == LS_WRITE_LOCK_HELD);
+    wlocked = ism_common_tryWriteLockACLList( );
+    CU_ASSERT(wlocked != 0);
+    rlocked = ism_common_tryReadLockACLList( );
+    CU_ASSERT(rlocked != 0);
+
+    //release lock
+    ism_protocol_unlockACLList(&locks);
+    CU_ASSERT(locks.rlac == LS_NO_LOCK_HELD);
+    wlocked = ism_common_tryWriteLockACLList( );
+    CU_ASSERT(wlocked == 0);
+    ism_common_unlockACLList(); 
+}
+
+/*
+ * Array of hash map tests for server_utils APIs to CUnit framework.
+ */
+CU_TestInfo ISM_Util_CUnit_Filter[] =
+  {
+        { "ACLReadLockTest",     CUnit_acl_readlock_test },
+        { "ACLWriteLockTest",    CUnit_acl_writelock_test },
+        { "ACLNotPersist",       CUint_acl_notPersist_test },
+        { "ACLPersistRead",      CUint_acl_persistRead_test },
+        { "ACLDontPersistWrite", CUint_acl_dontPersistWrite_test },
+        { "ACLUpgradeRead",      CUint_acl_upgradeReadLock_test },
+       CU_TEST_INFO_NULL
+  };
+

--- a/server_utils/test/testFilterCUnit.h
+++ b/server_utils/test/testFilterCUnit.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2012-2021 Contributors to the Eclipse Foundation
+ * 
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+/*
+ * File: testFilterCUnit.h
+ * Component: server
+ * SubComponent: server_utils
+ *
+ * Created on:
+ *     Author:
+ * --------------------------------------------------------------
+ *
+ *
+ */
+
+#ifndef TESTFILTERCUNIT_H_
+#define TESTFILTERCUNIT_H_
+
+#include <CUnit/CUnit.h>
+#include <CUnit/Basic.h>
+#include <selector.h>
+
+XAPI int ism_common_tryReadLockACLList( void );
+XAPI int ism_common_tryWriteLockACLList( void );
+XAPI void ism_common_unlockACLList( void );
+XAPI void ism_protocol_lockACLList(bool write, ismMessageSelectionLockStrategy_t * lockStrategy);
+XAPI void ism_protocol_unlockACLList(ismMessageSelectionLockStrategy_t * lockStrategy);
+
+/**
+ * Perform initialization for timer test suite.
+ */
+extern int initFilterCUnitSuite(void);
+
+/**
+ * Clean up after timer test suite is executed.
+ */
+extern int cleanFilterCUnitSuite(void);
+
+/**   
+ * Test array for timer test suite.
+ */
+extern CU_TestInfo ISM_Util_CUnit_Filter[];
+
+#endif /* TESTFILTERCUNIT_H_ */

--- a/server_utils/test/testUtilCUnit.c
+++ b/server_utils/test/testUtilCUnit.c
@@ -61,6 +61,7 @@
 #include "testTLS.h"
 #include "testUtilsMemHandlerCUnit.h"
 #include "testSASLScram.h"
+#include "testFilterCUnit.h"
 extern CU_TestInfo ISM_Util_CUnit_Protoex[];
 void ism_common_initUtil2(int type);
 
@@ -145,8 +146,9 @@ CU_SuiteInfo ISM_Util_CUnit_test_basicsuites[] = {
     IMA_TEST_SUITE("DelaySuite", initDelayTests, cleanDelayTests,  (CU_TestInfo *)ISM_Throttle_CUnit_Delay),
     IMA_TEST_SUITE("TLSSuite", NULL, NULL, ISM_Util_CUnit_TLS),
     IMA_TEST_SUITE("Protocol Extension", NULL, NULL, ISM_Util_CUnit_Protoex),
-	IMA_TEST_SUITE("MemHandler", initMemHandlerSuite, cleanMemHandlerSuite, ISM_Util_CUnit_memHandler),
-	IMA_TEST_SUITE("SASLScram", initSASLScramSuite, cleanSASLScramSuite, ISM_Util_CUnit_SASLScram),
+    IMA_TEST_SUITE("MemHandler", initMemHandlerSuite, cleanMemHandlerSuite, ISM_Util_CUnit_memHandler),
+    IMA_TEST_SUITE("SASLScram", initSASLScramSuite, cleanSASLScramSuite, ISM_Util_CUnit_SASLScram),
+    IMA_TEST_SUITE("FilterSuite", initFilterCUnitSuite, cleanFilterCUnitSuite, ISM_Util_CUnit_Filter),
     CU_SUITE_INFO_NULL,
 };
 
@@ -168,8 +170,9 @@ CU_SuiteInfo ISM_Util_CUnit_test_allsuites[] = {
     IMA_TEST_SUITE("DelaySuite", initDelayTests, cleanDelayTests,  (CU_TestInfo *)ISM_Throttle_CUnit_Delay),
     IMA_TEST_SUITE("TLSSuite", NULL, NULL, ISM_Util_CUnit_TLS),
     IMA_TEST_SUITE("Protocol Extension", NULL, NULL, ISM_Util_CUnit_Protoex),
-	IMA_TEST_SUITE("MemHandler", initMemHandlerSuite, cleanMemHandlerSuite, ISM_Util_CUnit_memHandler),
-	IMA_TEST_SUITE("SASLScram", initSASLScramSuite, cleanSASLScramSuite, ISM_Util_CUnit_SASLScram),
+    IMA_TEST_SUITE("MemHandler", initMemHandlerSuite, cleanMemHandlerSuite, ISM_Util_CUnit_memHandler),
+    IMA_TEST_SUITE("SASLScram", initSASLScramSuite, cleanSASLScramSuite, ISM_Util_CUnit_SASLScram),
+    IMA_TEST_SUITE("FilterSuite", initFilterCUnitSuite, cleanFilterCUnitSuite, ISM_Util_CUnit_Filter),
     CU_SUITE_INFO_NULL,
 };
 


### PR DESCRIPTION
Added ismMessageSelectionLockStrategy_t which allows you to specify the lock strategy used for the acl lock when processing rlac. Allows a read lock to persist between repeated calls rather than unlocking and relocking. 

Added ismEngine_DelivererContext_t which contains the ismMessageSelectionLockStrategy_t  when trying to process messages and put them onto a queue (which calls the selection code).

Every 1000 calls to lock, it will release the read lock and regain it, this allows any waiting calls for the write lock to get in and avoid problems during failover.