### PR TITLE
Move platform.dat and store.init to data dir

### DIFF
--- a/Documentation/doc_infocenter/com.ibm.ism.doc/Upgrading/up00021_.dita
+++ b/Documentation/doc_infocenter/com.ibm.ism.doc/Upgrading/up00021_.dita
@@ -17,6 +17,7 @@ simple steps outlined here.
         <ol>
             <li>Packages have been renamed and made more granular</li>
             <li>Directories have different locations</li>
+            <li>An important marker file has changed location</li>
             <li>TLS keys used for validating peers in HA pairs and clusters have changed</li>
         </ol>
         <p>In the following sections we'll look at each change then the actions required during migration</p>
@@ -95,6 +96,18 @@ simple steps outlined here.
         </table>
     </section>
     <section>
+        <title>Change of location of marker file</title>
+        <p>There is a file (with path: <filepath>/var/lib/amlen-server/data/config/store.init</filepath>) that indicates
+        to Amlen that the persistent data store has been correctly initialised and is valid.</p>
+        
+        <p>Message Gateway used to use a different path under its install directory which will be removed as part of the 
+        uninstall of Message Gateway. Therefore <filepath>/var/lib/amlen-server/data/config/store.init</filepath> needs to 
+        be manually created as part of the migration process if persistent data (e.g. subscriptions and buffered
+        messages) are to be migrated. An empty file is all that is needed in order to cause the Message Gateway 
+        persistent data to be preserved e.g.:</p>
+        <codeblock>touch /var/lib/amlen-server/data/config/store.init</codeblock>
+    </section>
+    <section>
         <title>TLS keys for peers in HA Pairs and Clusters</title>
         <p>Both <ph conref="../TextEntities.dita#TextEntities/ISM"/> and 
          <ph conref="../TextEntities.dita#TextEntities/ISM_prev"/> contain default TLS keys used as a check on connections
@@ -122,8 +135,14 @@ simple steps outlined here.
                     <codeblock>sudo systemctl stop imaserver</codeblock>
                     </li>
                     <li>Uninstall <ph conref="../TextEntities.dita#TextEntities/ISM_prev"/></li>
-                    <li>Move the data directory:
-                    <codeblock>mv /var/messagesight /var/lib/amlen-server</codeblock>
+                    <li>Move the data directory (but have a link from the old location to the new
+                    as default Message Gateway configs reference paths under the old directory):
+                    <codeblock>mv /var/messagesight /var/lib/amlen-server
+ln -s /var/lib/amlen-server /var/messagesight</codeblock>
+                    </li>
+                    <li>Create the marker file that indicates Message Gateway persistent data should
+                    be used with Amlen:
+                    <codeblock>touch /var/lib/amlen-server/data/config/store.init</codeblock>
                     </li>
                     <li>Install <ph conref="../TextEntities.dita#TextEntities/ISM"/></li>
                     <li>Start the server:

--- a/server_admin/include/config.h
+++ b/server_admin/include/config.h
@@ -40,8 +40,8 @@ extern "C" {
  * - Static configuration - These configuration items can not be modified
  *   by the users using WebUI or CLI options. These items are stored in
  *   ismserver.cfg file. For examples:
- *   ConfigDir = /opt/ibm/imaserver/config
- *   LogDir = /opt/ibm/imaserver/logs
+ *   ConfigDir = /var/lib/amlen-server/config
+ *   LogDir = /var/lib/amlen-server/logs
  *   ....
  *
  * - Dynamic configuration - These configuration items are created, modified or

--- a/server_main/config/imaBackup.lst
+++ b/server_main/config/imaBackup.lst
@@ -1,4 +1,3 @@
-${IMA_SVR_INSTALL_PATH}/config/store.init
 ${IMA_SVR_INSTALL_PATH}/config/userPreferences.json
 ${IMA_SVR_INSTALL_PATH}/config/server_dynamic.cfg
 ${IMA_SVR_INSTALL_PATH}/config/mqcbridge_dynamic.cfg

--- a/server_main/scripts/initImaserverInstance.sh
+++ b/server_main/scripts/initImaserverInstance.sh
@@ -92,7 +92,7 @@ else
     chmod 770 ${IMADYNSERVERCFG} >> ${INITLOG} 2>&1
 
     # Set store.init file
-    touch ${IMA_SVR_INSTALL_PATH}/config/store.init
+    touch ${IMACFGDIR}/store.init
 
     # Make use of a unix domain socket for MQConnectivity connection into server
     sed -i 's%Interface\.!MQConnectivityEndpoint\( *\)=\( *\).*%Interface.!MQConnectivityEndpoint\1=\2'${DATADIR}'/MQConnectivityEndpoint_'${SHORT_UUID}'%g' ${IMASERVERCFG}

--- a/server_main/scripts/resetServerConfig.sh
+++ b/server_main/scripts/resetServerConfig.sh
@@ -166,7 +166,7 @@ perl -pi -e 's/\r\n$/\n/g' ${IMADYNSERVERCFG} >> ${INITLOG} 2>&1 3>&1
 chmod 770 ${IMADYNSERVERCFG} >> ${INITLOG} 2>&1 3>&1
 
 # Set store.init file
-touch ${IMA_SVR_INSTALL_PATH}/config/store.init
+touch ${IMA_DATA_INSTALL_PATH}/config/store.init
 
 touch ${IMACFGDIR}/MessageSightInstance.inited
 

--- a/server_main/scripts/setPlatformData.sh
+++ b/server_main/scripts/setPlatformData.sh
@@ -13,7 +13,7 @@
 
 PLATFORM_TYPE=0
 
-PLATFORM_DATA=${IMA_SVR_INSTALL_PATH}/config/platform.dat
+PLATFORM_DATA=${IMA_SVR_DATA_PATH}/data/config/platform.dat
 export PLATFORM_DATA
 
 # If dat file is already created before, get PLATFORM_LICE type

--- a/server_main/src/main.c
+++ b/server_main/src/main.c
@@ -58,7 +58,7 @@ static int sigterm_count = 0;
 static ism_handler_t sigtermHandler;
 extern int g_doUser2;
 
-const char * STORE_INITIALIZED_INDICATOR = IMA_SVR_INSTALL_PATH "/config/store.init";
+const char * STORE_INITIALIZED_INDICATOR = IMA_SVR_DATA_PATH "/config/store.init";
 
 #if !defined(_WIN32) && !defined(USE_EDITLINE) && !defined(NO_EDITLINE)
 #define USE_EDITLINE 1

--- a/server_utils/src/execinfo.c
+++ b/server_utils/src/execinfo.c
@@ -1561,7 +1561,7 @@ const char * ism_common_platform_type_str(ism_platformType_t ptype) {
 
 /*
  * Cache platform data variables
- * Expects platfm.dat file in config directory
+ * Expects platform.dat file in config directory
  */
 int ism_common_initPlatformDataFile(void) {
     int rc = ISMRC_OK;
@@ -1598,7 +1598,7 @@ int ism_common_initPlatformDataFile(void) {
     fread = getFileContent(platform_dat, buf, sizeof buf);
     if (fread == 0) {
         /* Create platform data file */
-        TRACE(3, "Initialize the platform data file.\n");
+        TRACE(3, "Initialize the platform data file as couldn't read %s.\n", platform_dat);
 
         bindir = (char *)ism_common_getStringConfig("BinDir");
         if (!bindir)  {
@@ -1632,6 +1632,7 @@ int ism_common_initPlatformDataFile(void) {
      * If the file exists, read it
      */
     if (fread) {
+        TRACE(3, "Successfully read platform data file: %s.\n", platform_dat);
         rc = 0;
 
         /* Check if platform is VM */


### PR DESCRIPTION
In Message Gateway these two files are under the install directory, we want them under the data dir esp as the install dir is different between MGW and Amlen (and the MGW install dir is removed when MGW is uninstalled).