### PR TITLE
Improve QoS1/QoS2 RLAC failover times

### DIFF
--- a/server_engine/src/clientState.c
+++ b/server_engine/src/clientState.c
@@ -42,13 +42,15 @@ void iecs_SLEReplayAddUnrelMsg(ietrReplayPhase_t phase,
                                ieutThreadData_t *pThreadData,
                                ismEngine_Transaction_t *pTran,
                                void *pEntry,
-                               ietrReplayRecord_t *pRecord);
+                               ietrReplayRecord_t *pRecord,
+                               ismEngine_DelivererContext_t *delivererContext);
 
 void iecs_SLEReplayRmvUnrelMsg(ietrReplayPhase_t phase,
                                ieutThreadData_t *pThreadData,
                                ismEngine_Transaction_t *pTran,
                                void *pEntry,
-                               ietrReplayRecord_t *pRecord);
+                               ietrReplayRecord_t *pRecord,
+                               ismEngine_DelivererContext_t * delivererContext);
 
 /*
  * Calculate a hash value for a key string.
@@ -4588,7 +4590,8 @@ void iecs_SLEReplayAddUnrelMsg(ietrReplayPhase_t phase,
                                ieutThreadData_t *pThreadData,
                                ismEngine_Transaction_t *pTran,
                                void *pEntry,
-                               ietrReplayRecord_t *pRecord)
+                               ietrReplayRecord_t *pRecord,
+                               ismEngine_DelivererContext_t *delivererContext)
 {
     iestSLEAddUMS_t *pSLEAdd = (iestSLEAddUMS_t *)pEntry;
     ismEngine_ClientState_t *pClient = pSLEAdd->pClient;
@@ -4655,7 +4658,8 @@ void iecs_SLEReplayRmvUnrelMsg(ietrReplayPhase_t phase,
                                ieutThreadData_t *pThreadData,
                                ismEngine_Transaction_t *pTran,
                                void *pEntry,
-                               ietrReplayRecord_t *pRecord)
+                               ietrReplayRecord_t *pRecord,
+                               ismEngine_DelivererContext_t * t)
 {
     iestSLERemoveUMS_t *pSLERmv = (iestSLERemoveUMS_t *)pEntry;
     ismEngine_ClientState_t *pClient = pSLERmv->pClient;

--- a/server_engine/src/destination.c
+++ b/server_engine/src/destination.c
@@ -965,11 +965,28 @@ int32_t ieds_publish(ieutThreadData_t *pThreadData,
         // Update stats directly if there is no transaction to do so
         if (pTran == NULL)
         {
+            ismEngine_DelivererContext_t delivererContext;
+            delivererContext.lockStrategy.rlac = LS_NO_LOCK_HELD;
+            delivererContext.lockStrategy.lock_persisted_counter = 0;
+            delivererContext.lockStrategy.lock_dropped_counter = 0;
             iett_SLEReplayReleaseNodes(Cleanup,
                                        pThreadData,
                                        NULL,
                                        pReleaseNodesSLE,
-                                       NULL);
+                                       NULL,
+                                       &delivererContext);
+            if ( delivererContext.lockStrategy.rlac == LS_READ_LOCK_HELD || delivererContext.lockStrategy.rlac == LS_WRITE_LOCK_HELD ) {
+                ieutTRACEL(pThreadData, 0, ENGINE_PERFDIAG_TRACE,
+                    "RLAC Lock was held and has now been released, debug: %d,%d\n",
+                    delivererContext.lockStrategy.lock_persisted_counter,delivererContext.lockStrategy.lock_dropped_counter);
+                ism_common_unlockACLList();
+            } else {
+                ieutTRACEL(pThreadData, 0, ENGINE_PERFDIAG_TRACE,
+                    "RLAC Lock was not held, debug: %d,%d\n",
+                    delivererContext.lockStrategy.lock_persisted_counter,delivererContext.lockStrategy.lock_dropped_counter);
+            } 
+
+            delivererContext.lockStrategy.rlac = LS_NO_LOCK_HELD;
         }
         else
         {

--- a/server_engine/src/destination.c
+++ b/server_engine/src/destination.c
@@ -811,12 +811,12 @@ int32_t ieds_publish(ieutThreadData_t *pThreadData,
                         }
                     }
                     if ( delivererContext.lockStrategy.rlac == LS_READ_LOCK_HELD || delivererContext.lockStrategy.rlac == LS_WRITE_LOCK_HELD ) {
-                        ieutTRACEL(pThreadData, 0, ENGINE_PERFDIAG_TRACE,
+                        ieutTRACEL(pThreadData, delivererContext.lockStrategy.lock_persisted_counter, ENGINE_PERFDIAG_TRACE,
                             "RLAC Lock was held and has now been released, debug: %d,%d\n",
                             delivererContext.lockStrategy.lock_persisted_counter,delivererContext.lockStrategy.lock_dropped_counter);
                         ism_common_unlockACLList();
                     } else {
-                        ieutTRACEL(pThreadData, 0, ENGINE_PERFDIAG_TRACE,
+                        ieutTRACEL(pThreadData, delivererContext.lockStrategy.lock_persisted_counter, ENGINE_PERFDIAG_TRACE,
                             "RLAC Lock was not held, debug: %d,%d\n",
                             delivererContext.lockStrategy.lock_persisted_counter,delivererContext.lockStrategy.lock_dropped_counter);
                     } 
@@ -976,12 +976,12 @@ int32_t ieds_publish(ieutThreadData_t *pThreadData,
                                        NULL,
                                        &delivererContext);
             if ( delivererContext.lockStrategy.rlac == LS_READ_LOCK_HELD || delivererContext.lockStrategy.rlac == LS_WRITE_LOCK_HELD ) {
-                ieutTRACEL(pThreadData, 0, ENGINE_PERFDIAG_TRACE,
+                ieutTRACEL(pThreadData, delivererContext.lockStrategy.lock_persisted_counter, ENGINE_PERFDIAG_TRACE,
                     "RLAC Lock was held and has now been released, debug: %d,%d\n",
                     delivererContext.lockStrategy.lock_persisted_counter,delivererContext.lockStrategy.lock_dropped_counter);
                 ism_common_unlockACLList();
             } else {
-                ieutTRACEL(pThreadData, 0, ENGINE_PERFDIAG_TRACE,
+                ieutTRACEL(pThreadData, delivererContext.lockStrategy.lock_persisted_counter, ENGINE_PERFDIAG_TRACE,
                     "RLAC Lock was not held, debug: %d,%d\n",
                     delivererContext.lockStrategy.lock_persisted_counter,delivererContext.lockStrategy.lock_dropped_counter);
             } 

--- a/server_engine/src/engine.c
+++ b/server_engine/src/engine.c
@@ -2616,12 +2616,12 @@ XAPI int32_t WARN_CHECKRC ism_engine_startMessageDelivery(
             }
         }
         if ( delivererContext.lockStrategy.rlac == LS_READ_LOCK_HELD || delivererContext.lockStrategy.rlac == LS_WRITE_LOCK_HELD ) {
-            ieutTRACEL(pThreadData, 0, ENGINE_PERFDIAG_TRACE,
+            ieutTRACEL(pThreadData, delivererContext.lockStrategy.lock_persisted_counter, ENGINE_PERFDIAG_TRACE,
                "RLAC Lock was held and has now been released, debug: %d,%d\n",
                delivererContext.lockStrategy.lock_persisted_counter,delivererContext.lockStrategy.lock_dropped_counter);
             ism_common_unlockACLList();
         } else {
-            ieutTRACEL(pThreadData, 0, ENGINE_PERFDIAG_TRACE,
+            ieutTRACEL(pThreadData, delivererContext.lockStrategy.lock_persisted_counter, ENGINE_PERFDIAG_TRACE,
                "RLAC Lock was not held, debug: %d,%d\n",
                delivererContext.lockStrategy.lock_persisted_counter,delivererContext.lockStrategy.lock_dropped_counter);
         } 

--- a/server_engine/src/intermediateQ.c
+++ b/server_engine/src/intermediateQ.c
@@ -5959,12 +5959,12 @@ static int32_t ieiq_asyncMessageDelivery(ieutThreadData_t           *pThreadData
                         , &delivererContext );
 
     if ( delivererContext.lockStrategy.rlac == LS_READ_LOCK_HELD || delivererContext.lockStrategy.rlac == LS_WRITE_LOCK_HELD ) {
-        ieutTRACEL(pThreadData, 0, ENGINE_PERFDIAG_TRACE,
+        ieutTRACEL(pThreadData, delivererContext.lockStrategy.lock_persisted_counter, ENGINE_PERFDIAG_TRACE,
                   "RLAC Lock was held and has now been released, debug: %d,%d\n",
                   delivererContext.lockStrategy.lock_persisted_counter,delivererContext.lockStrategy.lock_dropped_counter);
         ism_common_unlockACLList();
     } else {
-        ieutTRACEL(pThreadData, 0, ENGINE_PERFDIAG_TRACE,
+        ieutTRACEL(pThreadData, delivererContext.lockStrategy.lock_persisted_counter, ENGINE_PERFDIAG_TRACE,
                   "RLAC Lock was not held, debug: %d,%d\n",
                    delivererContext.lockStrategy.lock_persisted_counter,delivererContext.lockStrategy.lock_dropped_counter);
     }

--- a/server_engine/src/intermediateQ.c
+++ b/server_engine/src/intermediateQ.c
@@ -121,7 +121,8 @@ int32_t ieiq_SLEReplayPut( ietrReplayPhase_t Phase
                       , void *pEntry
                       , ietrReplayRecord_t *pRecord
                       , ismEngine_AsyncData_t *pAsyncData
-                      , ietrAsyncTransactionData_t *asyncTran);
+                      , ietrAsyncTransactionData_t *asyncTran
+                      , ismEngine_DelivererContext_t *delivererContext);
 
 int32_t ieiq_consumeAckCommitted(
                 ieutThreadData_t               *pThreadData,
@@ -4202,7 +4203,8 @@ int32_t ieiq_SLEReplayPut( ietrReplayPhase_t Phase
                          , void *pEntry
                          , ietrReplayRecord_t *pRecord
                          , ismEngine_AsyncData_t *pAsyncData
-                         , ietrAsyncTransactionData_t *asyncTran)
+                         , ietrAsyncTransactionData_t *asyncTran
+                         , ismEngine_DelivererContext_t *delivererContext)
 {
     int32_t rc=OK;
     ieiqSLEPut_t *pSLE = (ieiqSLEPut_t *)pEntry;
@@ -5942,6 +5944,11 @@ static int32_t ieiq_asyncMessageDelivery(ieutThreadData_t           *pThreadData
     bool     deliverMoreMsgs           = false;
     uint64_t storeOps                  = 0;
 
+    ismEngine_DelivererContext_t delivererContext;
+    delivererContext.lockStrategy.rlac = LS_NO_LOCK_HELD;
+    delivererContext.lockStrategy.lock_persisted_counter = 0;
+    delivererContext.lockStrategy.lock_dropped_counter = 0;
+
     ieiq_deliverMessages( pThreadData
                         , Q
                         , deliveryInfo->usedNodes
@@ -5949,7 +5956,19 @@ static int32_t ieiq_asyncMessageDelivery(ieutThreadData_t           *pThreadData
                         , &callCompleteWaiterActions
                         , &deliverMoreMsgs
                         , &storeOps
-                        , NULL );
+                        , &delivererContext );
+
+    if ( delivererContext.lockStrategy.rlac == LS_READ_LOCK_HELD || delivererContext.lockStrategy.rlac == LS_WRITE_LOCK_HELD ) {
+        ieutTRACEL(pThreadData, 0, ENGINE_PERFDIAG_TRACE,
+                  "RLAC Lock was held and has now been released, debug: %d,%d\n",
+                  delivererContext.lockStrategy.lock_persisted_counter,delivererContext.lockStrategy.lock_dropped_counter);
+        ism_common_unlockACLList();
+    } else {
+        ieutTRACEL(pThreadData, 0, ENGINE_PERFDIAG_TRACE,
+                  "RLAC Lock was not held, debug: %d,%d\n",
+                   delivererContext.lockStrategy.lock_persisted_counter,delivererContext.lockStrategy.lock_dropped_counter);
+    }
+    delivererContext.lockStrategy.rlac = LS_NO_LOCK_HELD;
 
     //We've finished delivering this message... remove the entry that calls this function
     //so if checkWaiters goes async we don't try to deliver this message again

--- a/server_engine/src/multiConsumerQ.c
+++ b/server_engine/src/multiConsumerQ.c
@@ -169,12 +169,14 @@ int32_t iemq_SLEReplayPut(ietrReplayPhase_t Phase, ieutThreadData_t *pThreadData
                           ismEngine_Transaction_t *pTran, void *pEntry,
                           ietrReplayRecord_t *pRecord,
                           ismEngine_AsyncData_t *pAsyncData,
-                          ietrAsyncTransactionData_t *asyncTran);
+                          ietrAsyncTransactionData_t *asyncTran,
+                          ismEngine_DelivererContext_t *delivererContext);
 
 // Softlog replay - for confirmMessageDelivery(consumed)
 void iemq_SLEReplayConsume(ietrReplayPhase_t Phase,
                            ieutThreadData_t *pThreadData, ismEngine_Transaction_t *pTran,
-                           void *pEntry, ietrReplayRecord_t *pRecord);
+                           void *pEntry, ietrReplayRecord_t *pRecord,
+                           ismEngine_DelivererContext_t *delivererContext);
 
 static inline uint32_t iemq_choosePageSize(iemqQueue_t *Q);
 
@@ -7587,7 +7589,8 @@ void iemq_SLEReplayConsume( ietrReplayPhase_t Phase
                           , ieutThreadData_t *pThreadData
                           , ismEngine_Transaction_t *pTran
                           , void *pEntry
-                          , ietrReplayRecord_t *pRecord)
+                          , ietrReplayRecord_t *pRecord
+                          , ismEngine_DelivererContext_t * delivererContext)
 {
     int32_t rc;
     iemqSLEConsume_t *pSLE = (iemqSLEConsume_t *) pEntry;
@@ -7676,7 +7679,7 @@ void iemq_SLEReplayConsume( ietrReplayPhase_t Phase
                (void)iemq_checkWaiters( pThreadData
                                       , (ismQHandle_t) Q
                                       , NULL
-                                      , NULL);
+                                      , delivererContext );
            }
 
            //Now reduce the pre delete count which Q to be deleted...
@@ -7946,7 +7949,8 @@ int32_t iemq_SLEReplayPut( ietrReplayPhase_t Phase
                          , void *pEntry
                          , ietrReplayRecord_t *pRecord
                          , ismEngine_AsyncData_t *pAsyncData
-                         , ietrAsyncTransactionData_t *asyncTran)
+                         , ietrAsyncTransactionData_t *asyncTran
+                         , ismEngine_DelivererContext_t *delivererContext)
 {
     int32_t rc = OK;
     iemqSLEPut_t *pSLE = (iemqSLEPut_t *) pEntry;

--- a/server_engine/src/simpQ.c
+++ b/server_engine/src/simpQ.c
@@ -67,7 +67,8 @@ void iesq_SLEReplayPut( ietrReplayPhase_t Phase
                       , ieutThreadData_t *pThreadData
                       , ismEngine_Transaction_t *pTran
                       , void *pEntry
-                      , ietrReplayRecord_t *pRecord );
+                      , ietrReplayRecord_t *pRecord
+                      , ismEngine_DelivererContext_t * delivererContext );
 
 static inline void iesq_fullExpiryScan( ieutThreadData_t *pThreadData
                                       , iesqQueue_t *Q
@@ -1516,7 +1517,8 @@ void iesq_SLEReplayPut( ietrReplayPhase_t Phase
                       , ieutThreadData_t *pThreadData
                       , ismEngine_Transaction_t *pTran
                       , void *pEntry 
-                      , ietrReplayRecord_t *pRecord )
+                      , ietrReplayRecord_t *pRecord
+                      , ismEngine_DelivererContext_t * delivererContext  )
 {
     iesqSLEPut_t *pSLE = (iesqSLEPut_t *)pEntry;
 
@@ -1536,7 +1538,7 @@ void iesq_SLEReplayPut( ietrReplayPhase_t Phase
                                          , NULL
                                          , pSLE->pMsg
                                          , IEQ_MSGTYPE_INHERIT 
-                                         , NULL ))
+                                         , delivererContext ))
                 {
                     // If we failed, we need to decrement the message usage count which was
                     // incremented during the original put.

--- a/server_engine/src/storeMQRecords.c
+++ b/server_engine/src/storeMQRecords.c
@@ -41,13 +41,15 @@ void iesm_SLEReplayAddQMgr(ietrReplayPhase_t phase,
                            ieutThreadData_t *pThreadData,
                            ismEngine_Transaction_t *pTran,
                            void *pEntry,
-                           ietrReplayRecord_t *pRecord);
+                           ietrReplayRecord_t *pRecord,
+                           ismEngine_DelivererContext_t *delivererContext);
 
 void iesm_SLEReplayRmvQMgr(ietrReplayPhase_t phase,
                            ieutThreadData_t *pThreadData,
                            ismEngine_Transaction_t *pTran,
                            void *pEntry,
-                           ietrReplayRecord_t *pRecord);
+                           ietrReplayRecord_t *pRecord,
+                           ismEngine_DelivererContext_t *delivererContext);
 
 
 //****************************************************************************
@@ -985,7 +987,8 @@ void iesm_SLEReplayAddQMgr(ietrReplayPhase_t phase,
                            ieutThreadData_t *pThreadData,
                            ismEngine_Transaction_t *pTran,
                            void *pEntry,
-                           ietrReplayRecord_t *pRecord)
+                           ietrReplayRecord_t *pRecord,
+                           ismEngine_DelivererContext_t *delivererContext)
 {
     iesmSLEAddQMgrXID_t *pSLEAdd = (iesmSLEAddQMgrXID_t *)pEntry;
     iesmQMgrXidRecord_t *pQMgrXidRec = pSLEAdd->pQMgrXidRec;
@@ -1022,7 +1025,8 @@ void iesm_SLEReplayRmvQMgr(ietrReplayPhase_t phase,
                     ieutThreadData_t *pThreadData,
                     ismEngine_Transaction_t *pTran,
                     void *pEntry,
-                    ietrReplayRecord_t *pRecord)
+                    ietrReplayRecord_t *pRecord,
+                    ismEngine_DelivererContext_t *delivererContext)
 {
     iesmSLERemoveQMgrXID_t *pSLERmv = (iesmSLERemoveQMgrXID_t *)pEntry;
     iesmQMgrXidRecord_t *pQMgrXidRec = pSLERmv->pQMgrXidRec;

--- a/server_engine/src/topicTree.h
+++ b/server_engine/src/topicTree.h
@@ -1329,7 +1329,8 @@ void iett_SLEReplayReleaseNodes(ietrReplayPhase_t        Phase,
                                 ieutThreadData_t        *pThreadData,
                                 ismEngine_Transaction_t *pTran,
                                 void                    *entry,
-                                ietrReplayRecord_t      *pRecord);
+                                ietrReplayRecord_t      *pRecord,
+                                ismEngine_DelivererContext_t *delivererContext);
 
 //****************************************************************************
 /// @brief Initialize the topic tree values in the per thread data structure

--- a/server_engine/src/topicTreeInternal.h
+++ b/server_engine/src/topicTreeInternal.h
@@ -632,7 +632,8 @@ void iett_SLEReplayUpdateRetained(ietrReplayPhase_t        Phase,
                                   ieutThreadData_t        *pThreadData,
                                   ismEngine_Transaction_t *pTran,
                                   void                    *entry,
-                                  ietrReplayRecord_t      *pRecord);
+                                  ietrReplayRecord_t      *pRecord,
+                                  ismEngine_DelivererContext_t *delivererContext);
 
 //****************************************************************************
 /// @brief  Replay an AddSubscription (iettSLEAddSubscription_t) soft log entry
@@ -646,7 +647,8 @@ void iett_SLEReplayAddSubscription(ietrReplayPhase_t        Phase,
                                    ieutThreadData_t        *pThreadData,
                                    ismEngine_Transaction_t *pTran,
                                    void                    *entry,
-                                   ietrReplayRecord_t      *pRecord);
+                                   ietrReplayRecord_t      *pRecord,
+                                   ismEngine_DelivererContext_t *delivererContext);
 
 //****************************************************************************
 /// @brief  Replay an old Store Subscription Definition (iettSLEOldStoreSubscDefn_t)
@@ -661,7 +663,8 @@ void iett_SLEReplayOldStoreSubscDefn(ietrReplayPhase_t        Phase,
                                      ieutThreadData_t        *pThreadData,
                                      ismEngine_Transaction_t *pTran,
                                      void                    *entry,
-                                     ietrReplayRecord_t      *pRecord);
+                                     ietrReplayRecord_t      *pRecord,
+                                     ismEngine_DelivererContext_t * delivererContext);
 
 //****************************************************************************
 /// @brief  Replay an old Store Subscription Properties (iettSLEOldStoreSubscProps_t)
@@ -676,7 +679,8 @@ void iett_SLEReplayOldStoreSubscProps(ietrReplayPhase_t        Phase,
                                       ieutThreadData_t        *pThreadData,
                                       ismEngine_Transaction_t *pTran,
                                       void                    *entry,
-                                      ietrReplayRecord_t      *pRecord);
+                                      ietrReplayRecord_t      *pRecord,
+                                      ismEngine_DelivererContext_t * delivererContext);
 
 //****************************************************************************
 /// @brief  Add an iettSLEUpdateRetained_t to the inflight chain for the

--- a/server_engine/src/topicTreeRestore.c
+++ b/server_engine/src/topicTreeRestore.c
@@ -333,7 +333,8 @@ void iett_SLEReplayUpdateRetained(ietrReplayPhase_t        Phase,
                                   ieutThreadData_t        *pThreadData,
                                   ismEngine_Transaction_t *pTran,
                                   void                    *entry,
-                                  ietrReplayRecord_t      *pRecord)
+                                  ietrReplayRecord_t      *pRecord,
+                                  ismEngine_DelivererContext_t *delivererContext)
 {
     int32_t rc;
 
@@ -837,7 +838,8 @@ void iett_SLEReplayAddSubscription(ietrReplayPhase_t        Phase,
                                    ieutThreadData_t        *pThreadData,
                                    ismEngine_Transaction_t *pTran,
                                    void                    *entry,
-                                   ietrReplayRecord_t      *pRecord)
+                                   ietrReplayRecord_t      *pRecord,
+                                   ismEngine_DelivererContext_t *delivererContext)
 {
     iettSLEAddSubscription_t *pSLE = entry;
 
@@ -888,7 +890,8 @@ void iett_SLEReplayOldStoreSubscDefn(ietrReplayPhase_t        Phase,
                                      ieutThreadData_t        *pThreadData,
                                      ismEngine_Transaction_t *pTran,
                                      void                    *entry,
-                                     ietrReplayRecord_t      *pRecord)
+                                     ietrReplayRecord_t      *pRecord,
+                                     ismEngine_DelivererContext_t * delivererContext)
 {
     iettSLEOldStoreSubscDefn_t *pSLE = entry;
 
@@ -920,7 +923,8 @@ void iett_SLEReplayOldStoreSubscProps(ietrReplayPhase_t        Phase,
                                       ieutThreadData_t        *pThreadData,
                                       ismEngine_Transaction_t *pTran,
                                       void                    *entry,
-                                      ietrReplayRecord_t      *pRecord)
+                                      ietrReplayRecord_t      *pRecord,
+                                      ismEngine_DelivererContext_t * delivererContext)
 {
     iettSLEOldStoreSubscProps_t *pSLE = entry;
 
@@ -948,7 +952,8 @@ void iett_SLEReplayReleaseNodes(ietrReplayPhase_t        Phase,
                                 ieutThreadData_t        *pThreadData,
                                 ismEngine_Transaction_t *pTran,
                                 void                    *entry,
-                                ietrReplayRecord_t      *pRecord)
+                                ietrReplayRecord_t      *pRecord,
+                                ismEngine_DelivererContext_t *delivererContext)
 {
     iettSLEReleaseNodes_t *pSLE = entry;
 

--- a/server_engine/src/transaction.c
+++ b/server_engine/src/transaction.c
@@ -3359,11 +3359,11 @@ static int32_t ietr_softLogCommit( ietrTransactionControl_t *pControl
 
             if (pSLE->fSync)
             {
-                pSLE->ReplayFn.syncFn(Phase, pThreadData, pTran, pSLE+1, pRecord);
+                pSLE->ReplayFn.syncFn(Phase, pThreadData, pTran, pSLE+1, pRecord, NULL);
             }
             else
             {
-                rc = pSLE->ReplayFn.asyncFn(Phase, pThreadData, pTran, pSLE+1, pRecord, pAsyncData, pAsyncTranData);
+                rc = pSLE->ReplayFn.asyncFn(Phase, pThreadData, pTran, pSLE+1, pRecord, pAsyncData, pAsyncTranData, NULL);
                 assert (rc == OK || rc == ISMRC_AsyncCompletion);
                 assert (Phase != Cleanup || rc == OK);
                 if (rc != OK)
@@ -3695,11 +3695,11 @@ static void ietr_softLogRollback( ietrTransactionControl_t *pControl
 
             if (pSLE->fSync)
             {
-                pSLE->ReplayFn.syncFn(Phase, pThreadData, pTran, pSLE+1, pRecord);
+                pSLE->ReplayFn.syncFn(Phase, pThreadData, pTran, pSLE+1, pRecord, NULL);
             }
             else
             {
-                rc = pSLE->ReplayFn.asyncFn(Phase, pThreadData, pTran, pSLE+1, pRecord, NULL, NULL);
+                rc = pSLE->ReplayFn.asyncFn(Phase, pThreadData, pTran, pSLE+1, pRecord, NULL, NULL, NULL);
 
                 assert(rc == OK); //We'll allow an async completion here... but not coded yet
             }
@@ -3974,11 +3974,11 @@ int32_t ietr_endSavepoint( ieutThreadData_t *pThreadData
 
                 if (pSLE->fSync)
                 {
-                    pSLE->ReplayFn.syncFn(action, pThreadData, pTran, pSLE+1, &record);
+                    pSLE->ReplayFn.syncFn(action, pThreadData, pTran, pSLE+1, &record, NULL);
                 }
                 else if (pSLE->ReplayFn.asyncFn)
                 {
-                    rc = pSLE->ReplayFn.asyncFn(action, pThreadData, pTran, pSLE+1, &record, NULL, NULL);
+                    rc = pSLE->ReplayFn.asyncFn(action, pThreadData, pTran, pSLE+1, &record, NULL, NULL, NULL);
                     assert (rc == OK);
                 }
 

--- a/server_engine/src/transaction.h
+++ b/server_engine/src/transaction.h
@@ -112,7 +112,8 @@ typedef void (*ietrSLESyncReplay_t)( ietrReplayPhase_t
                                    , ieutThreadData_t *
                                    , ismEngine_Transaction_t *
                                    , void *
-                                   , ietrReplayRecord_t *);
+                                   , ietrReplayRecord_t *
+                                   , ismEngine_DelivererContext_t * delivererContext );
 
 //An SLE Replay Function that might go async
 typedef int32_t (*ietrSLEAsyncReplay_t)( ietrReplayPhase_t
@@ -121,7 +122,8 @@ typedef int32_t (*ietrSLEAsyncReplay_t)( ietrReplayPhase_t
                                        , void *
                                        , ietrReplayRecord_t *
                                        , ismEngine_AsyncData_t *
-                                       , ietrAsyncTransactionData_t *);
+                                       , ietrAsyncTransactionData_t *
+                                       , ismEngine_DelivererContext_t * delivererContext );
 
 typedef union tag_ietrSLEReplay_t
 {

--- a/server_engine/test/test_transaction.c
+++ b/server_engine/test/test_transaction.c
@@ -1925,7 +1925,8 @@ void testSavepointFunc(ietrReplayPhase_t        Phase,
                        ieutThreadData_t        *pThreadData,
                        ismEngine_Transaction_t *pTran,
                        void                    *entry,
-                       ietrReplayRecord_t      *pRecord)
+                       ietrReplayRecord_t      *pRecord,
+                       ismEngine_DelivererContext_t * delivererContext)
 {
     testSPContext_t *pContext = *(testSPContext_t **)entry;
 


### PR DESCRIPTION
Uses the delivererContext to allow holding the read lock on the ACL list during processing of messages using QoS1 or QoS2