### PR TITLE
Download Page for 1.0rc1

### DIFF
--- a/server_build/buildcontainer/jenkins.updatedownloadwww
+++ b/server_build/buildcontainer/jenkins.updatedownloadwww
@@ -1,0 +1,69 @@
+//This is a more customisable version of the default Jenkinsfile stored at in the root folder of the project
+//This version allows (in particular) choosing which Linux distribution to build on
+pipeline {
+
+    parameters{
+        gitParameter branchFilter: 'origin/(.*)', defaultValue: 'master', name: 'branchName', type: 'PT_BRANCH',description: 'Branch to get the websites/download HTML Download page(s) from'
+    }
+
+  agent {
+    kubernetes {
+      label "amlen-downloadwww-update-pod"
+      yaml """
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+  - name: jnlp
+    resources:
+      limits:
+        memory: "300Mi"
+        cpu: "200m"
+      requests:
+        memory: "300Mi"
+        cpu: "200m"
+    volumeMounts:
+    - name: volume-known-hosts
+      mountPath: /home/jenkins/.ssh
+  volumes:
+  - name: volume-known-hosts
+    configMap:
+      name: known-hosts
+"""
+    }
+  }
+  
+
+
+    stages {
+        stage('DeployDownloadWWW') {
+            steps {
+                container('jnlp') {
+                    sshagent ( ['projects-storage.eclipse.org-bot-ssh']) {
+                        sh '''
+                            pwd
+                            echo ${GIT_BRANCH}
+                            NOORIGIN_BRANCH=${GIT_BRANCH#origin/} # turns origin/master into master
+                            scp -o BatchMode=yes -r websites/download/* genie.amlen@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/amlen/
+                        '''
+                    }
+                }
+            }
+        }
+    }
+    post {
+        // send a mail on unsuccessful and fixed builds
+        unsuccessful { // means unstable || failure || aborted
+            emailext subject: 'Build $BUILD_STATUS $PROJECT_NAME #$BUILD_NUMBER!', 
+            body: '''Check console output at $BUILD_URL to view the results.''',
+            recipientProviders: [culprits(), requestor()], 
+            to: 'levell@uk.ibm.com'
+        }
+        fixed { // back to normal
+            emailext subject: 'Build $BUILD_STATUS $PROJECT_NAME #$BUILD_NUMBER!', 
+            body: '''Check console output at $BUILD_URL to view the results.''',
+            recipientProviders: [culprits(), requestor()], 
+            to: 'levell@uk.ibm.com'
+        }
+    }
+}

--- a/server_build/buildcontainer/jenkins.updatedownloadwww
+++ b/server_build/buildcontainer/jenkins.updatedownloadwww
@@ -1,5 +1,8 @@
-//This is a more customisable version of the default Jenkinsfile stored at in the root folder of the project
-//This version allows (in particular) choosing which Linux distribution to build on
+//The download page (https://download.eclipse.org/amlen) is different to the main Amlen website
+//(https://www.eclipse.org/amlen). The main website has it's own git repo. The downloads page 
+//can only be updated (as far as I can tell) from the Jenkins for the main product source repo.
+//Thus this jenkins script which copes the simple download page files from the product source
+//to the Eclipse download server
 pipeline {
 
     parameters{

--- a/websites/download/downloads.css
+++ b/websites/download/downloads.css
@@ -1,0 +1,30 @@
+/* Sidebars style based on https://every-layout.dev/layouts/sidebar/ */
+
+.mainpage {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--s1);
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+.mainpage > :first-child {
+  flex-grow: 1;
+  background: #cccccc;
+  padding: 1em;
+}
+
+.mainpage > :last-child {
+  flex-basis: 0;
+  flex-grow: 999;
+  min-inline-size: 50%;
+  padding-left: 1em;
+  padding-right: 1em;
+}
+
+#maincontent > h1 {
+   background: #4444aa;
+   color: #ffffff;
+   padding: 0.5em;
+   font-family: Arial, Helvetica, sans-serif;
+   margin-top: 0px;
+ }

--- a/websites/download/index.html
+++ b/websites/download/index.html
@@ -1,12 +1,52 @@
+<!DOCTYPE html>
 <html>
 <head>
 <title>Eclipse Amlen Downloads</title>
+<link rel="stylesheet" href="downloads.css">
+</head>
 <body>
-<h1>Eclipse Amlen&trade; Downloads</h1>
-<ul>
-<li>The latest release is <a href="https://download.eclipse.org/amlen/releases/1.0rc1/">1.0rc1</a></li>
-<li>Older Releases can be seen <a href="https://download.eclipse.org/amlen/releases">here</a></li>
-<li><a href="https://download.eclipse.org/amlen/snapshots/">Snapshot builds</a> of dev branches are also available</li>
-</ul>
+<div class="mainpage">
+  <div id="sidebar">
+  <p><a href="https://www.eclipse.org/amlen/">Amlen Home</a></p>
+  <p>Releases</p>
+  <ul>
+  <li><a href="#1.0rc1">1.0rc1</a></li>
+  </ul>
+  <p>Other:</p>
+  <ul>
+  <li><a href="https://download.eclipse.org/amlen/releases">Older Releases</a></li>
+  <li><a href="https://download.eclipse.org/amlen/snapshots/">Recent Dev Builds</a></li>
+  <li><a href="https://archive.eclipse.org/amlen/">Archives</a></li>
+  </ul>
+  </div>
+  <div id="maincontent">
+     <h1>Eclipse Amlen&trade; Downloads</h1>
+     
+     <h3>1.0 Release Candidate 1 (1.0rc1)</h3>
+     <a name="1.0rc1"></a>
+     <p>1.0rc1 is now available!</p>
+     <ul>
+     <li>CentOS7/RHEL7 downloads: <a href="https://www.eclipse.org/downloads/download.php?file=/amlen/releases/1.0rc1/centos7/EclipseAmlenServer-centos7-1.0.0.0-20220420-1047_eclipse.tar.gz">Amlen Server 1.0rc1</a>, 
+<a href="https://www.eclipse.org/downloads/download.php?file=/amlen/releases/1.0rc1/centos7/EclipseAmlenWebUI-centos7-1.0.0.0-20220420-1047_eclipse.tar.gz">Amlen WebUI 1.0rc1</a>, 
+<a href="https://www.eclipse.org/downloads/download.php?file=/amlen/releases/1.0rc1/centos7/EclipseAmlenBridge-centos7-1.0.0.0-20220420-1047_eclipse.tar.gz">Amlen Bridge 1.0rc1</a>, 
+<a href="https://download.eclipse.org/amlen/releases/1.0rc1/centos7/contrib/">Others</a></li>
+     <li>RHEL8/AlmaLinux8: <a href="https://www.eclipse.org/downloads/download.php?file=/amlen/releases/1.0rc1/alma8/EclipseAmlenServer-almalinux8-1.0.0.0-20220420-1047_eclipse.tar.gz">Amlen Server 1.0rc1</a>, 
+<a href="https://www.eclipse.org/downloads/download.php?file=/amlen/releases/1.0rc1/alma8/EclipseAmlenWebUI-almalinux8-1.0.0.0-20220420-1047_eclipse.tar.gz">Amlen WebUI 1.0rc1</a>, 
+<a href="https://www.eclipse.org/downloads/download.php?file=/amlen/releases/1.0rc1/alma8/EclipseAmlenBridge-almalinux8-1.0.0.0-20220420-1047_eclipse.tar.gz">Amlen Bridge 1.0rc1</a>, 
+<a href="https://download.eclipse.org/amlen/releases/1.0rc1/alma8/contrib/">Others</a><br />
+NB: The WebUI requires openldap-servers which is available in the RHEL <a href="https://access.redhat.com/articles/4348511">CodeReady Builder</a> stream for RHEL(<a href="https://serverfault.com/questions/997896/how-to-enable-powertools-repository-in-centos-8">PowerTools</a> for CentOS/AlmaLinux). <br/> Alternatively openldap-servers is available from the <a href="https://repo.symas.com/sofl/rhel8/">symas</a> repo. </li>
+     <li>Fedora (34/35):  <a href="https://www.eclipse.org/downloads/download.php?file=/amlen/releases/1.0rc1/fedora/EclipseAmlenServer-fedora34-1.0.0.0-20220420-1047_eclipse.tar.gz">Amlen Server 1.0rc1</a>, 
+<a href="https://www.eclipse.org/downloads/download.php?file=/amlen/releases/1.0rc1/fedora/EclipseAmlenWebUI-fedora34-1.0.0.0-20220420-1047_eclipse.tar.gz">Amlen WebUI 1.0rc1</a>, 
+<a href="https://www.eclipse.org/downloads/download.php?file=/amlen/releases/1.0rc1/fedora/EclipseAmlenBridge-fedora34-1.0.0.0-20220420-1047_eclipse.tar.gz">Amlen Bridge 1.0rc1</a>, 
+<a href="https://download.eclipse.org/amlen/releases/1.0rc1/fedora/contrib/">Others</a></li>
+     </ul>
+     
+     <h3>Older Releases</h3>
+     <p>Older Releases can be seen <a href="https://download.eclipse.org/amlen/releases">here</a> (or in the <a href="https://archive.eclipse.org/amlen/">archives</a>)</p>
+     
+     <h3>Snapshot Builds</h3>
+     <p><a href="https://download.eclipse.org/amlen/snapshots/">Snapshot builds</a> of dev branches are also available. Some older snapshot may be available in the <a href="https://archive.eclipse.org/amlen/">archives</a></p>
+  </div>
+</div>
 </body>
 </html>

--- a/websites/download/index.html
+++ b/websites/download/index.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+<title>Eclipse Amlen Downloads</title>
+<body>
+<h1>Eclipse Amlen&trade; Downloads</h1>
+<ul>
+<li>The latest release is <a href="https://download.eclipse.org/amlen/releases/1.0rc1/">1.0rc1</a></li>
+<li>Older Releases can be seen <a href="https://download.eclipse.org/amlen/releases">here</a></li>
+<li><a href="https://download.eclipse.org/amlen/snapshots/">Snapshot builds</a> of dev branches are also available</li>
+</ul>
+</body>
+</html>


### PR DESCRIPTION
We need to have a human-readable download page (rather than the auto-generated directory listing). This is the first pass (for 1.0rc1)