### PR TITLE
[patch] Explain WebUI prereqs needed on RHEL8

### DIFF
--- a/Documentation/doc_infocenter/com.ibm.ism.doc/QuickStartGuide/qs00058_.dita
+++ b/Documentation/doc_infocenter/com.ibm.ism.doc/QuickStartGuide/qs00058_.dita
@@ -23,6 +23,15 @@
 </info>
 </step>
             <step>
+                <cmd>Ensure the system has access to the prequisite software. On RHEL7/CentOS7/Fedora no
+                action in required but on RHEL8 (and compatible distributions like AlmaLinux 8 
+                and CentOS 8 Stream) the package openldap-servers is not available by default so
+                It is necessary to enable the <xref href="https://access.redhat.com/articles/4348511" format="html" scope="external">CodeReady Builder stream for RHEL</xref>
+                (<xref href="https://serverfault.com/questions/997896/how-to-enable-powertools-repository-in-centos-8" format="html" scope="external">PowerTools</xref> for CentOS/AlmaLinux) 
+                or alternatively enable the <xref href="https://repo.symas.com/sofl/rhel8/" format="html" scope="external">symas</xref> repository 
+                (all of which contain openldap-servers).</cmd>
+            </step>
+            <step>
                 <cmd> Ensure that the current working directory is the sub-directory which contains
                     the RPM file that you unpacked when you prepared the .tz file.</cmd>
             </step>


### PR DESCRIPTION
Te download page:
https://download.eclipse.org/amlen/
Mentions that on RHEL8 to install the WebUI you need to enable an extra repository of software but it's not actually mentioned in our docs. 
This adds a short explanation to our docs