### PR TITLE
[patch] By default use 1.0.0.0 of the buildcontainers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ kind: Pod
 spec:
   containers:
   - name: amlen-centos7-build
-    image: quay.io/amlen/amlen-builder-centos7:latest
+    image: quay.io/amlen/amlen-builder-centos7:1.0.0.0
     command:
     - cat
     tty: true

--- a/server_build/buildcontainer/Jenkinsfile.distro
+++ b/server_build/buildcontainer/Jenkinsfile.distro
@@ -6,6 +6,7 @@ pipeline {
         gitParameter branchFilter: 'origin/(.*)', defaultValue: 'master', name: 'branchName', type: 'PT_BRANCH'
         choice(name: 'distro', choices: ['centos7','alma8','fedora'], description: 'Linux distribution to build on')
         string(name: 'buildId',    defaultValue: '',   description: 'Build Identifier to ensure build can be easily identified (set blank to autogenerate - default)')
+        string(name: 'buildcontainerVersion', defaultValue: '1.0.0.0', description: 'Version of the amlen-build-(distro) container to use to do the build')
     }
 
   agent {
@@ -17,7 +18,7 @@ kind: Pod
 spec:
   containers:
   - name: amlen-${distro}-build
-    image: "quay.io/amlen/amlen-builder-${distro}:latest"
+    image: "quay.io/amlen/amlen-builder-${distro}:${buildcontainerVersion}"
     command:
     - cat
     tty: true


### PR DESCRIPTION
Pinning the version of the buildcontainers, simplifies updating them... it means we can make a new version of the containers and have one branch test that version without affecting other branches (which will not use the updated container).