### PR TITLE
[patch] Allow uploading multiple contributed file at once

### DIFF
--- a/server_build/buildcontainer/bulkcontriblists/alma8
+++ b/server_build/buildcontainer/bulkcontriblists/alma8
@@ -1,0 +1,3 @@
+AmlenSDK-${ISM_VERSION_ID}-1.el8.x86_64.rpm
+AmlenProtocolPlugin-${ISM_VERSION_ID}-1.el8.x86_64.rpm
+MQBridge.README.txt

--- a/server_build/buildcontainer/bulkcontriblists/centos7
+++ b/server_build/buildcontainer/bulkcontriblists/centos7
@@ -1,0 +1,3 @@
+AmlenSDK-${ISM_VERSION_ID}-1.el7.x86_64.rpm
+AmlenProtocolPlugin-${ISM_VERSION_ID}-1.el7.x86_64.rpm
+MQBridge.README.txt

--- a/server_build/buildcontainer/bulkcontriblists/fedora
+++ b/server_build/buildcontainer/bulkcontriblists/fedora
@@ -1,0 +1,3 @@
+AmlenSDK-${ISM_VERSION_ID}-1.fc35.x86_64.rpm
+AmlenProtocolPlugin-${ISM_VERSION_ID}-1.fc35.x86_64.rpm
+MQBridge.README.txt

--- a/server_build/buildcontainer/jenkins.uploadcontrib
+++ b/server_build/buildcontainer/jenkins.uploadcontrib
@@ -26,9 +26,10 @@ spec:
     }
   }
     parameters{
-        string(name: 'contributedpath',  defaultValue: '', description: 'Path to file to contribute under amlen.org/contribbuilds')
+        string(name: 'contributedpath',  defaultValue: '', description: 'Path to file to contribute under amlen.org/contribbuilds (not used in bulk mode)')
         string(name: 'buildpath', defaultValue: '', description: 'Path to build to add files to e.g. snapshots/master/20211109-2203_eclipse/centos7')
-        gitParameter branchFilter: 'origin/(.*)', defaultValue: 'master', name: 'branchName', type: 'PT_BRANCH', description: 'Branch to get the server_build/buildcontainer/jenkins.uploadcontrib script from'
+        booleanParam(name: 'BulkMode', defaultValue: true, description: 'If false, gets "contributedpath", If true gets file list from the server_build/buildcontainer/bulkcontriblists dir')
+        gitParameter branchFilter: 'origin/(.*)', defaultValue: 'master', name: 'branchName', type: 'PT_BRANCH', description: 'Branch to get the server_build/buildcontainer/jenkins.uploadcontrib script (and bulk file upload list) from'
 
     }
     
@@ -37,14 +38,12 @@ spec:
             steps {
                 container('jnlp') {
                     sshagent ( ['projects-storage.eclipse.org-bot-ssh']) {
-                        sh """
-                            which wget
+                        sh '''
                             df -h
                             pwd
-                            wget "https://amlen.org/contribbuilds/${contributedpath}"
-                            ssh -o BatchMode=yes genie.amlen@projects-storage.eclipse.org mkdir -p /home/data/httpd/download.eclipse.org/amlen/${buildpath}/contrib
-                            scp -o BatchMode=yes ${contributedpath} genie.amlen@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/amlen/${buildpath}/contrib/
-                        """
+
+                            bash server_build/buildcontainer/uploadcontrib.sh
+                        '''
                     }
                 }
             }

--- a/server_build/buildcontainer/uploadcontrib.sh
+++ b/server_build/buildcontainer/uploadcontrib.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Copyright (c) 2012-2021 Contributors to the Eclipse Foundation
+# 
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+# 
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+# 
+# SPDX-License-Identifier: EPL-2.0
+
+#
+# This script is really the guts of the jenkins.uploadcontrib jenkins
+# script (but it is hard to embed in that file due to having to escape the script 
+# as a groovy string)
+#
+if [ "${BulkMode}" == "true" ]
+then
+    BULKFILEDIR="server_build/buildcontainer/bulkcontriblists"
+    BULKFILELISTS="${BULKFILEDIR}/*"
+
+    #We'd like to do our normal variable inserts on file list like:
+    #python server_build/path_parser.py -m dirreplace -i ${BULKFILEDIR} -o ${BULKFILEDIR}
+    #sadly python isn't installed but perl is so we can jury-rig inserting the version:
+    VERSION_STRING=`perl -ne '/ISM_VERSION_ID=(.*)/ and print "$1"' server_build/paths.properties`
+    perl -pi -e "s/\\\$\\{ISM_VERSION_ID\\}/${VERSION_STRING}/g" ${BULKFILELISTS}
+    
+    for listfilepath in $BULKFILELISTS
+    do
+        listfilename=`basename ${listfilepath}`
+        echo "Processing ${listfilepath}"
+        dldir="dl-${listfilename}"
+        mkdir ${dldir}
+        wget -nH -np --cut-dirs=1 -i ${listfilepath} -P ${dldir} -B 'https://amlen.org/contribbuilds/'
+        ssh -o BatchMode=yes genie.amlen@projects-storage.eclipse.org mkdir -p /home/data/httpd/download.eclipse.org/amlen/${buildpath}/${listfilename}/contrib
+        scp -o BatchMode=yes ${dldir}/* genie.amlen@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/amlen/${buildpath}/${listfilename}/contrib/
+        rm -rf ${dldir}
+    done
+else
+    wget "https://amlen.org/contribbuilds/${contributedpath}"
+    ssh -o BatchMode=yes genie.amlen@projects-storage.eclipse.org mkdir -p /home/data/httpd/download.eclipse.org/amlen/${buildpath}/contrib
+    scp -o BatchMode=yes ${contributedpath} genie.amlen@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/amlen/${buildpath}/contrib/
+fi


### PR DESCRIPTION
Currently uploading the jms client etc for each distro we support involves a jenkins job for each file+distro combination and is very painful. This allows them all to be uploaded in one shot.