### PR TITLE
[patch] Dont use symlinks in installdir to point to data files

### DIFF
--- a/server_gui/scripts/postInstallWebUI.sh
+++ b/server_gui/scripts/postInstallWebUI.sh
@@ -518,34 +518,19 @@ function update_liberty_ldap_password() {
 if [ ! -d "${WLPDIR}"/usr ]
 then
     echo "${WLPDIR}/usr does not exist at start."  >> ${INSTALL_LOG}
-    if [ -L "${WLPINSTALLDIR}"/usr ]
+    if [ -d ${WLPINSTALLDIR}/usr ]
     then
-        if [ -d "${WLPINSTALLDIR}"/usr.org ]
+        cp -r ${WLPINSTALLDIR}/usr "${WLPDIR}"/.
+        rm -rf ${WLPINSTALLDIR}/usr.org
+        echo "Copied ${WLPINSTALLDIR}/usr to ${WLPDIR}/usr"  >> ${INSTALL_LOG}
+    else
+        if [ -d ${WLPINSTALLDIR}/usr.org ]
         then
             cp -r ${WLPINSTALLDIR}/usr.org "${WLPDIR}"/usr
-            echo "Contents of ${WLPINSTALLDIR}/usr.org  copied into ${WLPDIR}/usr, existing symlink = ${WLPINSTALLDIR}/usr "  >> ${INSTALL_LOG}
+            echo "Contents of ${WLPINSTALLDIR}/usr.org  copied into ${WLPDIR}/usr"  >> ${INSTALL_LOG}
         else
             echo "Can not continue. WebUI Application directory is missing." >> ${INSTALL_LOG}
             exit 255
-        fi
-    else
-        if [ -d ${WLPINSTALLDIR}/usr ]
-        then
-            cp -r ${WLPINSTALLDIR}/usr "${WLPDIR}"/.
-            rm -rf ${WLPINSTALLDIR}/usr.org
-            mv ${WLPINSTALLDIR}/usr ${WLPINSTALLDIR}/usr.org
-            ln -s "${WLPDIR}"/usr ${WLPINSTALLDIR}/usr
-            echo "Setup ${WLPINSTALLDIR}/usr as a symlink to ${WLPDIR}/usr, after creating usr.org backup"  >> ${INSTALL_LOG}
-        else
-            if [ -d ${WLPINSTALLDIR}/usr.org ]
-            then
-                cp -r ${WLPINSTALLDIR}/usr.org "${WLPDIR}"/usr
-                ln -s "${WLPDIR}"/usr ${WLPINSTALLDIR}/usr
-                echo "Contents of ${WLPINSTALLDIR}/usr.org  copied into ${WLPDIR}/usr, new symlink = ${WLPINSTALLDIR}/usr "  >> ${INSTALL_LOG}
-            else
-                echo "Can not continue. WebUI Application directory is missing." >> ${INSTALL_LOG}
-                exit 255
-            fi
         fi
     fi
 else
@@ -556,9 +541,6 @@ else
         if [ -d ${WLPINSTALLDIR}/usr ]
         then
             cp ${WLPINSTALLDIR}/usr/servers/ISMWebUI/apps/ISMWebUI.war "${WLPDIR}"/usr/servers/ISMWebUI/apps/.
-            rm -rf ${WLPINSTALLDIR}/usr.org
-            mv ${WLPINSTALLDIR}/usr ${WLPINSTALLDIR}/usr.org
-            ln -s "${WLPDIR}"/usr ${WLPINSTALLDIR}/usr
             echo "Updating ${WLPDIR}/usr/servers/ISMWebUI/apps/ISMWebUI.war" >> ${INSTALL_LOG}
         fi
     fi

--- a/server_gui/scripts/preUninstallWebUI.sh
+++ b/server_gui/scripts/preUninstallWebUI.sh
@@ -20,9 +20,9 @@ if [ -L "${IMA_WEBUI_APPSRV_INSTALL_PATH}/usr" ] ; then
     rm "${IMA_WEBUI_APPSRV_INSTALL_PATH}/usr"
 fi
 
-#If a backup of the usr dir was made, restore the original
+#If a backup of the usr dir was made, remove it
 if [ -d "${IMA_WEBUI_APPSRV_INSTALL_PATH}/usr.org" ] ; then
-    mv  "${IMA_WEBUI_APPSRV_INSTALL_PATH}/usr.org"  "${IMA_WEBUI_APPSRV_INSTALL_PATH}/usr"
+    rm  "${IMA_WEBUI_APPSRV_INSTALL_PATH}/usr.org"
 fi
 
 # Copy postUninstall script to either /tmp or to IMSTMPDIR location if it exists

--- a/server_gui/scripts/startWebUI.sh
+++ b/server_gui/scripts/startWebUI.sh
@@ -33,7 +33,6 @@ then
     export PATH=${IMA_WEBUI_INSTALL_PATH}/ibm-java-x86_64-80/jre/bin:$PATH
 fi
 
-
 if [ ! -f "${LDAPDIR}"/.accountsCreated ]; then
     echo "There was a problem with the rpm post-install script. Please reinstall the rpm." >> "$START_LOG"
     exit 2
@@ -56,6 +55,9 @@ fi
 if [ -f ${WLPDIR}/usr/servers/ISMWebUI/server.xml ]; then
     sed -i 's/${keystore_id}/defaultKeyStore/' ${WLPDIR}/usr/servers/ISMWebUI/server.xml
 fi
+
+#Tell Liberty where to find the WebUI files
+export WLP_USER_DIR=${WLPDIR}/usr
 
 exec 200> /tmp/imawebui.lock
 flock -e -n 200 2> /dev/null


### PR DESCRIPTION
Rather that altering the install files we use liberty env vars to point to the data (altering the install directory causes issues during upgrades and also for k8s/OCP)