### PR TITLE
[patch] change openldap database used for webui to be mbd backed

### DIFF
--- a/server_gui/config/imawebui_slapd.conf
+++ b/server_gui/config/imawebui_slapd.conf
@@ -29,7 +29,7 @@ timelimit 3600
 #######################################################################
 # database definitions
 #######################################################################
-database bdb
+database mdb
 suffix "dc=ism.ibm,dc=com"
 rootdn "cn=Directory Manager,dc=ism.ibm,dc=com"
 rootpw {SSHA}yka7fCsuvNpKIexAVUq3p9hT8uQCMmgE
@@ -38,16 +38,7 @@ directory ${IMA_WEBUI_DATA_PATH}/openldap-data
 # Indices to maintain
 index objectClass eq
 
-# specifies the number of entries that the LDAP backend will maintain in memory.
-cachesize 10000
-
-# check point whenever 1k data bytes written or
-# 15 minutes has elapsed whichever occurs first
-checkpoint 1 15
+Maxsize 10485760
 
 # specifies that the database does NOT need to be updated immediately with any in-memory records.
 dbnosync
-
-# Auto remove old transaction log files
-dbconfig set_flags DB_LOG_AUTOREMOVE
-


### PR DESCRIPTION
With the new webui upgrade code, we don't fiddle with the ldap config during an upgrade so we can change to using an mdb database (compatible with openldap 2.6) and people upgrading to a webui with this fix will not have their existing ldap databases altered.