### PR TITLE
[patch] Disable rpath errors for mqcbridge (as we have for normal build) (in main branch)

### DIFF
--- a/server_build/distrobuild/mqcbridge.spec
+++ b/server_build/distrobuild/mqcbridge.spec
@@ -61,6 +61,9 @@ export DONT_STRIP=1
 export IMASERVER_BASE_DIR=$RPM_BUILD_DIR/broot/rpmtree
 #cp -dpR $IMASERVER_BASE_DIR/* "$RPM_BUILD_ROOT/"
 mv $IMASERVER_BASE_DIR/* "$RPM_BUILD_ROOT/"
+#We set runpaths to find the mqclient libraries relative to our install location
+#In recent version of Fedora this causes errors unless suppressed via:
+export QA_RPATHS=$(( 0x0002|0x0004|0x0008))
 
 %files
 %defattr (-, root, bin)


### PR DESCRIPTION
F35 doesn't like the library path (runpath) we burn into the bridge so it can find the mqclient libraries.
We've disabled this error for other libraries. I want to revisit our runpath settings but want to unblock the build
(This is the main branch equivalent of the 1.0.0.x change: https://github.com/eclipse/amlen/pull/74)