### PR TITLE
Allow building on RHEL9

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ export USE_REAL_TRANSLATIONS=true
 export SLESNORPMS=yes
 export IMASERVER_BASE_DIR=$BROOT/rpmtree
 export JAVA_HOME=<suitable Java 8 SDK e.g. /etc/alternatives/java_sdk>
+export PATH=$JAVA_HOME/bin:$PATH
 
 cd $SROOT/server_build
 ant -f $SROOT/server_build/build.xml  2>&1 | tee /tmp/ant.log

--- a/client_build/build.xml
+++ b/client_build/build.xml
@@ -13,7 +13,8 @@
 #
 -->
 
-<project name="imaclient" default="build-client" basedir=".">
+<project name="imaclient" default="build-client" basedir="."
+    xmlns:if="ant:if" xmlns:unless="ant:unless">
 	<echo/>
 	<echo/>
 	<echo>==== invoking ant build for client ====</echo>
@@ -82,16 +83,10 @@
 	</condition>
 
 	<echo message="Client build version=${ISM_VERSION_ID}" />
-
-
-	<!-- the following property reflects how the version will look like in a file name -->
-	<propertyregex property="ISM_VERSION_ID_NAME"
-	               input="${ISM_VERSION_ID}"
-	               regexp=" "
-	               replace="."
-	               global="true"
-	               override="true"
-		           defaultValue="${ISM_VERSION_ID}" />
+	<!-- We used to take spaces out of the version and replace them with dots but this
+	     required ant-contrib - now we'll just rely on having no spaces in the version 
+		 (as it's used in file names)-->
+	<property name="ISM_VERSION_ID_NAME" value="${ISM_VERSION_ID}" />
 
 	<!-- build server projects first -->
 	<target name="build-client" depends="client_init2, build_jms">
@@ -410,14 +405,12 @@
 				<arg value="@{project}" />
 				<arg value="${ISM_VERSION_ID}.${buildLabel}" />
 			</exec>
-        	<if>
-            	<equals arg1="${retcode}" arg2="0"/>
-	            <else>
-	                <echo>==== @{project} coverage failed ====</echo>
-	                <echo file="${workspace}/build_log/@{project}.errorcode"
-	                      message="@{project} coverage failed with exit code ${retcode} "/>
-        	    </else>
-	        </if>
+			<condition property="coverage.succeeded" >
+				<equals arg1="${retcode}" arg2="0"/>
+			</condition>
+            <echo unless:set="coverage.succeeded">==== @{project} coverage failed ====</echo>
+	        <echo unless:set="coverage.succeeded" file="${workspace}/build_log/@{project}.errorcode"
+	                message="@{project} coverage failed with exit code ${retcode} "/>
 		</sequential>
 	</macrodef>
 </project>

--- a/client_jms/build.xml
+++ b/client_jms/build.xml
@@ -54,8 +54,6 @@
 
 	<property name="imaclientjms_test.jar" location="${client.jms.lib.dir}/imaclientjms_test.jar"/>
 
-	<property name="java8.dir" location="${env.JAVA_HOME}" />
-
 	<fileset dir="${server.translation.dir}/xml" id="jmsclient_translations">
 		<include name="**/ism_jmsclient_tms.xml" />
 	</fileset>
@@ -224,7 +222,7 @@
                use="true"
                splitindex="true"
                noqualifier="java.*"
-      	       executable="${java8.dir}/bin/javadoc"
+      	       executable="javadoc"
                windowtitle="${IMA_PRODUCTNAME_FULL} Javadoc Reference"
       >
          <doctitle><![CDATA[<h1>${IMA_PRODUCTNAME_FULL} Javadoc Reference</h1>]]></doctitle>

--- a/client_plugin/build.xml
+++ b/client_plugin/build.xml
@@ -60,8 +60,6 @@
 
 	<property name="imaclientplugin_test.jar" location="${client.plugin.lib.dir}/imaclientplugin_test.jar"/>
 
-	<property name="java8.dir" location="${env.JAVA_HOME}" />
-		
 	<fileset dir="${server.translation.dir}/xml" id="pluginclient_translations">
 		<include name="**/*.xml" />
 	</fileset>
@@ -295,7 +293,7 @@
                use="true"
                splitindex="false"
                noqualifier="java.*"
-      	       executable="${java8.dir}/bin/javadoc"
+      	       executable="javadoc"
                windowtitle="Eclipse Amlen Javadoc Reference"
       >
          <doctitle><![CDATA[<h1>Eclipse Amlen plug-in reference</h1>]]></doctitle>
@@ -344,7 +342,7 @@
 	               use="true"
 	               splitindex="false"
 	               noqualifier="java.*"
-	               executable="${java8.dir}/bin/javadoc"
+	               executable="javadoc"
 	               windowtitle="Eclipse Amlen JSON Message Protocol Plugin Javadoc Reference"
 	      >
 	         <doctitle><![CDATA[<h1>Eclipse Amlen json_msg reference</h1>]]></doctitle>
@@ -392,7 +390,7 @@
 	               use="true"
 	               splitindex="false"
 	               noqualifier="java.*"
-	               executable="${java8.dir}/bin/javadoc"
+	               executable="javadoc"
 	               windowtitle="Eclipse Amlen REST Message Protocol Plugin Javadoc Reference"
 	      >
 	         <doctitle><![CDATA[<h1>Eclipse Amlen restmsg reference</h1>]]></doctitle>

--- a/server_admin/src/ltpautils.c
+++ b/server_admin/src/ltpautils.c
@@ -513,8 +513,8 @@ static int ism_security_ltpaV1GenUserInfoSignature(
     // Obtain a handle to the digest
     md = EVP_get_digestbyname(LTPA_DIGEST);
     if (md == (EVP_MD *) NULL) {
-	    TRACE(7, "EVP_get_digestbyname error\n");
-	    return retVal;
+        TRACE(7, "EVP_get_digestbyname error\n");
+        return retVal;
     }
 
     // Create a new digest context
@@ -527,26 +527,26 @@ static int ism_security_ltpaV1GenUserInfoSignature(
     // Load the SHA1 digest into our context
     rc = EVP_DigestInit_ex(pCtx, md, NULL);
     if (rc != 1) {
-	    TRACE(7, "EVP_DigestInit error: %d\n", rc);
-	    EVP_MD_CTX_free(pCtx);
-	    return retVal;
+        TRACE(7, "EVP_DigestInit error: %d\n", rc);
+        EVP_MD_CTX_free(pCtx);
+        return retVal;
     }
 
     // Digest the data
     rc = EVP_DigestUpdate(pCtx, (const void *) userInfoBuf,
-			(unsigned int)signedLen);
+            (unsigned int)signedLen);
     if (rc != 1) {
-	    TRACE(7, "EVP_DigestUpdate error: %d\n", rc);
+        TRACE(7, "EVP_DigestUpdate error: %d\n", rc);
         EVP_MD_CTX_free(pCtx);
-	    return retVal;
+        return retVal;
     }
 
     // Load the digest into our output buffer
     rc = EVP_DigestFinal(pCtx, digest, &shaLen);
     if (rc != 1) {
-	    TRACE(7, "EVP_DigestFinal error: %d\n", rc);
+        TRACE(7, "EVP_DigestFinal error: %d\n", rc);
         EVP_MD_CTX_free(pCtx);
-	    return retVal;
+        return retVal;
     }
 
     EVP_MD_CTX_free(pCtx);
@@ -569,53 +569,53 @@ static int ism_security_ltpaV1GenUserInfoSignature(
     // Encrypt the buffer
     if (retVal == ISMRC_OK)
     {
-	unsigned char *encBuf;
+    unsigned char *encBuf;
 
-	encBuf = (unsigned char *) alloca(sizeof(unsigned char) * 
-					scratchBufLen);
+    encBuf = (unsigned char *) alloca(sizeof(unsigned char) * 
+                    scratchBufLen);
 
-	// Perform the RSA encrypt without any automatic padding
+    // Perform the RSA encrypt without any automatic padding
     rc = RSA_private_encrypt((int)scratchBufLen, scratchBuf, encBuf, keys->rsa, RSA_NO_PADDING);
-	if ( rc != scratchBufLen ) {
-	    TRACE(7, "RSA_private_encrypt error: %d\n", rc);
-	    //ism_common_free(ism_memory_admin_misc,scratchBuf);
-	    //ism_common_free(ism_memory_admin_misc,encBuf);
-	    return ISMRC_Error;
-	}
+    if ( rc != scratchBufLen ) {
+        TRACE(7, "RSA_private_encrypt error: %d\n", rc);
+        //ism_common_free(ism_memory_admin_misc,scratchBuf);
+        //ism_common_free(ism_memory_admin_misc,encBuf);
+        return ISMRC_Error;
+    }
 
-	//ism_common_free(ism_memory_admin_misc,scratchBuf);
-	scratchBuf = encBuf;
+    //ism_common_free(ism_memory_admin_misc,scratchBuf);
+    scratchBuf = encBuf;
 
-	int remainder = 0;
-	int tmp = 0;
-	int i = 0;
-	unsigned char *mod = keys->rsaMod;
+    int remainder = 0;
+    int tmp = 0;
+    int i = 0;
+    unsigned char *mod = keys->rsaMod;
 
-	for (i = 0; i <= (LTPA_NLEN - 1); i++)
-	{
-	    tmp = (remainder * 256) + mod[i];
-	    remainder = tmp%2;
-	    tmp = tmp/2;
-	    if (scratchBuf[i] != tmp)
+    for (i = 0; i <= (LTPA_NLEN - 1); i++)
+    {
+        tmp = (remainder * 256) + mod[i];
+        remainder = tmp%2;
+        tmp = tmp/2;
+        if (scratchBuf[i] != tmp)
             break;
-	}
-	if (i < scratchBufLen && scratchBuf[i] > tmp)
-	    ism_security_complementSmodN(scratchBuf, mod);
+    }
+    if (i < scratchBufLen && scratchBuf[i] > tmp)
+        ism_security_complementSmodN(scratchBuf, mod);
 
-	// Base64 encode the result
-	char b64SigBuf[1024];
-	char * b64Sig = (char *)&b64SigBuf;
-	int encodeSize = ism_common_toBase64((char *) scratchBuf,b64Sig, scratchBufLen);
+    // Base64 encode the result
+    char b64SigBuf[1024];
+    char * b64Sig = (char *)&b64SigBuf;
+    int encodeSize = ism_common_toBase64((char *) scratchBuf,b64Sig, scratchBufLen);
 
-	if (encodeSize>0)
-	{
-		*sigBuf = ism_common_strdup(ISM_MEM_PROBE(ism_memory_admin_misc,1000),b64Sig);
-	    *sigBufLen = encodeSize;
-	}
-	else
-	{
-	    retVal = ISMRC_Error;
-	}
+    if (encodeSize>0)
+    {
+        *sigBuf = ism_common_strdup(ISM_MEM_PROBE(ism_memory_admin_misc,1000),b64Sig);
+        *sigBufLen = encodeSize;
+    }
+    else
+    {
+        retVal = ISMRC_Error;
+    }
     }
 
     // Free the intermediate buffer
@@ -808,8 +808,8 @@ static int ism_security_ltpaV2GenUserInfoSignature(
     int signEncodeSize= ism_common_toBase64((char *)binsig, signEncode, binsigLen);
     
     if(signEncodeSize>0){
-    	 rc = ISMRC_OK;
-    	 *sigBuf = ism_common_strdup(ISM_MEM_PROBE(ism_memory_admin_misc,1000),signEncode);
+         rc = ISMRC_OK;
+         *sigBuf = ism_common_strdup(ISM_MEM_PROBE(ism_memory_admin_misc,1000),signEncode);
     }
 
 CLEANUP:
@@ -894,7 +894,7 @@ static int ism_security_ltpaParseUserInfoAndExpiration(ismLTPA_t *keys,
         // TRACE(9, "LTPA Token Key=Value pair: %s=%s\n", key, val);
 
         if ( !strcmp(key, EXPIRE_KEY )) {
-            *expirySecs = atol(val)/1000;		/* BEAM suppression: dereferencing NULL */
+            *expirySecs = atol(val)/1000;        /* BEAM suppression: dereferencing NULL */
         }
 
         if ( !strcmp(key, USER_KEY)) {
@@ -994,8 +994,8 @@ static int ism_security_ltpaV1DecodeAndDecrypt(
     // Base64 decode it
     char*  decodeText;
     long decodeTextLen = 0;
-	char decodeTextBuf[1024];
-	decodeText=(char* )&decodeTextBuf;
+    char decodeTextBuf[1024];
+    decodeText=(char* )&decodeTextBuf;
 
     decodeTextLen = ism_common_fromBase64(plainText,  decodeText , plainTextLen);
 
@@ -1008,14 +1008,14 @@ static int ism_security_ltpaV1DecodeAndDecrypt(
 
     // Obtain a DES-EDE cipher handle
     if(cipherV1==(EVP_CIPHER *) NULL){
-	    cipherV1 = EVP_get_cipherbyname(LTPA_CIPHER);
-	    if (cipherV1 == (EVP_CIPHER *) NULL) {
-	        TRACE(7, "EVP_get_cipherbyname\n");
-	        return ISMRC_LTPADecodeError;
-	    }
+        cipherV1 = EVP_get_cipherbyname(LTPA_CIPHER);
+        if (cipherV1 == (EVP_CIPHER *) NULL) {
+            TRACE(7, "EVP_get_cipherbyname\n");
+            return ISMRC_LTPADecodeError;
+        }
     }
-	cipher = cipherV1;
-	
+    cipher = cipherV1;
+    
     // Initialize the context
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
     EVP_CIPHER_CTX_init(pCipherCtx);
@@ -1133,18 +1133,18 @@ static int ism_security_ltpaV2DecodeAndDecrypt(
     }
     
     /*Null terminated the crypted buffer.*/
-	cryptBin[cryptBinLen]='\0';
+    cryptBin[cryptBinLen]='\0';
     
     // Obtain an AES-128-CBC cipher handle
     if(cipherV2==(EVP_CIPHER *) NULL){
-	    cipherV2 = EVP_get_cipherbyname( LTPA2_CIPHER);
-	    if (NULL == cipherV2) {
-	        TRACE(7, "EVP_get_cipherbyname error\n");
-	        return retVal;
-	    }
+        cipherV2 = EVP_get_cipherbyname( LTPA2_CIPHER);
+        if (NULL == cipherV2) {
+            TRACE(7, "EVP_get_cipherbyname error\n");
+            return retVal;
+        }
     }
-	cipher = cipherV2;
-	
+    cipher = cipherV2;
+    
     // Initialize the context
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
     EVP_CIPHER_CTX_init(pCipherCtx);
@@ -1229,8 +1229,9 @@ static int ism_security_decryptKey(
 #endif
     const EVP_CIPHER *cipher;
     int              sslrc;
-    unsigned int     shaLen;         
-    int              cryptLen;         
+    unsigned int     shaLen;
+    int              cryptLen;
+    int              decryptedLen = 0;
 
     // zero the return buffer and key buffer
     memset(pwKeyBytes, 0, DESKEY_LEN);
@@ -1238,89 +1239,90 @@ static int ism_security_decryptKey(
     // Make sure it base64 decoded okay
     if (inBufferLen%8 == 0)
     {
-    	// Obtain a handle to the digest
-	    md = EVP_get_digestbyname(LTPA_DIGEST);
-	    if (md == NULL) {
-	        TRACE(7, "EVP_get_digestbyname error.\n");
-	        return retVal;
-	    }
+        // Obtain a handle to the digest
+        md = EVP_get_digestbyname(LTPA_DIGEST);
+        if (md == NULL) {
+            TRACE(7, "EVP_get_digestbyname error.\n");
+            return retVal;
+        }
 
-	    // Create a new digest context
+        // Create a new digest context
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
         EVP_MD_CTX_init(pCtx);
 #else
         pCtx = EVP_MD_CTX_new();
 #endif
 
-	    // Load the SHA1 digest into our context
+        // Load the SHA1 digest into our context
         sslrc = EVP_DigestInit_ex(pCtx, md, NULL);
-	    if (sslrc != 1) {
-	        TRACE(7, "EVP_DigestInit error: %d\n", sslrc);
-	        EVP_MD_CTX_free(pCtx);
-	        return retVal;
-	    }
+        if (sslrc != 1) {
+            TRACE(7, "EVP_DigestInit error: %d\n", sslrc);
+            EVP_MD_CTX_free(pCtx);
+            return retVal;
+        }
 
-	    // Digest the password text
-	    sslrc = EVP_DigestUpdate(pCtx, (const void *) password, (unsigned int)strlen(password));
-	    if (sslrc != 1) {
-	        TRACE(7, "EVP_DigestUpdate error: %d\n", sslrc);
-	        EVP_MD_CTX_free(pCtx);
-	        return retVal;
-	    }
+        // Digest the password text
+        sslrc = EVP_DigestUpdate(pCtx, (const void *) password, (unsigned int)strlen(password));
+        if (sslrc != 1) {
+            TRACE(7, "EVP_DigestUpdate error: %d\n", sslrc);
+            EVP_MD_CTX_free(pCtx);
+            return retVal;
+        }
 
-	    // Load the digest into our DES key
-	    sslrc = EVP_DigestFinal_ex(pCtx, pwKeyBytes, &shaLen);
-	    if (sslrc != 1) {
-	        TRACE(7, "EVP_DigestFinal error: %d\n", sslrc);
-	        EVP_MD_CTX_free(pCtx);
-	        return retVal;
-	    }
+        // Load the digest into our DES key
+        sslrc = EVP_DigestFinal_ex(pCtx, pwKeyBytes, &shaLen);
+        if (sslrc != 1) {
+            TRACE(7, "EVP_DigestFinal error: %d\n", sslrc);
+            EVP_MD_CTX_free(pCtx);
+            return retVal;
+        }
 
-	    EVP_MD_CTX_free(pCtx);
+        EVP_MD_CTX_free(pCtx);
 
         // 3DES decrypt the data in unchained mode
-	    // Obtain a DES-EDE cipher handle
-	    cipher = EVP_get_cipherbyname(LTPA_CIPHER);
-	    if (cipher == (EVP_CIPHER *) NULL) {
-	        TRACE(7, "EVP_get_cipherbyname\n");
-	        return retVal;
-	    }
+        // Obtain a DES-EDE cipher handle
+        cipher = EVP_get_cipherbyname(LTPA_CIPHER);
+        if (cipher == (EVP_CIPHER *) NULL) {
+            TRACE(7, "EVP_get_cipherbyname\n");
+            return retVal;
+        }
 
-	    // Initialize cipher context
+        // Initialize cipher context
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
         EVP_CIPHER_CTX_init(pCipherCtx);
 #else
         pCipherCtx = EVP_CIPHER_CTX_new();
 #endif
 
-    	sslrc = EVP_DecryptInit(pCipherCtx, cipher, pwKeyBytes, NULL);
-	    if (sslrc != 1) {
-	        TRACE(7, "EVP_DecryptInit error: %d\n", sslrc);
-	        EVP_CIPHER_CTX_free(pCipherCtx);
-	        return retVal;
-	    }
+        sslrc = EVP_DecryptInit(pCipherCtx, cipher, pwKeyBytes, NULL);
+        if (sslrc != 1) {
+            TRACE(7, "EVP_DecryptInit error: %d\n", sslrc);
+            EVP_CIPHER_CTX_free(pCipherCtx);
+            return retVal;
+        }
 
-	    // Decrypt the cipher text
-	    decBufp = decBuffer;
-	    sslrc = EVP_DecryptUpdate(pCipherCtx, decBufp, &cryptLen, buffer, (int)inBufferLen);
-	    if (sslrc != 1) {
-	        TRACE(7, "EVP_DecryptUpdate error: %d\n", sslrc);
-	        EVP_CIPHER_CTX_free(pCipherCtx);
-	        return retVal;
-	    }
+        // Decrypt the cipher text
+        decBufp = decBuffer;
+        sslrc = EVP_DecryptUpdate(pCipherCtx, decBufp, &cryptLen, buffer, (int)inBufferLen);
+        if (sslrc != 1) {
+            TRACE(7, "EVP_DecryptUpdate error: %d\n", sslrc);
+            EVP_CIPHER_CTX_free(pCipherCtx);
+            return retVal;
+        }
 
-	    // Finish the decryption by decrypting any partial remaining block
-	    decBufp += cryptLen;
-	    sslrc = EVP_DecryptFinal(pCipherCtx, decBufp, &cryptLen);
-	    if (sslrc != 1) {
-	        TRACE(7, "EVP_DecryptFinal error: %d\n", sslrc);
-	        EVP_CIPHER_CTX_free(pCipherCtx);
-	        return retVal;
-	    }
+        // Finish the decryption by decrypting any partial remaining block
+        decryptedLen += cryptLen;
+        decBufp += cryptLen;
+        sslrc = EVP_DecryptFinal(pCipherCtx, decBufp, &cryptLen);
+        if (sslrc != 1) {
+            TRACE(7, "EVP_DecryptFinal error: %d\n", sslrc);
+            EVP_CIPHER_CTX_free(pCipherCtx);
+            return retVal;
+        }
+        decryptedLen += cryptLen;
+        EVP_CIPHER_CTX_free(pCipherCtx);
 
-	    EVP_CIPHER_CTX_free(pCipherCtx);
-
-        // trim off the PKCS5 pad
+        /*// trim off the PKCS5 pad - doesn't /appear to be needed
         size_t dataLen = inBufferLen;
         int    padLen = decBuffer[dataLen - 1];
 
@@ -1334,7 +1336,12 @@ static int ism_security_decryptKey(
             *retBufferLen = dataLen;
 
             retVal = ISMRC_OK;
-        }
+        }*/
+        memset(buffer, 0, LTPA_MAXPROPBUFFER);
+        memcpy(buffer, decBuffer, decryptedLen);
+        *retBufferLen = decryptedLen;
+
+        retVal = ISMRC_OK;
     }
 
     return retVal;
@@ -1382,7 +1389,7 @@ XAPI int ism_security_ltpaReadKeyfile(
     size_t        keylen        = 0;
 
     if ( !keyfile_path || !keyfile_password || *keyfile_path=='\0' ) {
-    	if(ltpaKey!=NULL) *ltpaKey=NULL;
+        if(ltpaKey!=NULL) *ltpaKey=NULL;
         ism_common_setError(ISMRC_NullArgument);
         return ISMRC_NullArgument;
     }
@@ -1397,21 +1404,21 @@ XAPI int ism_security_ltpaReadKeyfile(
 
     /*Initialize Ciphers for LTPAv1 and LTPAv2 for later use.*/
     if(cipherV1==(EVP_CIPHER *) NULL){
-	    cipherV1 = EVP_get_cipherbyname(LTPA_CIPHER);
-	    if (NULL == cipherV1) {
-	        TRACE(1, "EVP_get_cipherbyname error\n");
-	        ism_common_setError(ISMRC_LTPASSLError);
-	        return ISMRC_LTPASSLError;
-	    }
+        cipherV1 = EVP_get_cipherbyname(LTPA_CIPHER);
+        if (NULL == cipherV1) {
+            TRACE(1, "EVP_get_cipherbyname error\n");
+            ism_common_setError(ISMRC_LTPASSLError);
+            return ISMRC_LTPASSLError;
+        }
     }
 
     if(cipherV2==(EVP_CIPHER *) NULL){
-	    cipherV2 = EVP_get_cipherbyname( LTPA2_CIPHER);
-	    if (NULL == cipherV2) {
-	        TRACE(1, "EVP_get_cipherbyname error\n");
-	        ism_common_setError(ISMRC_LTPASSLError);
-	        return ISMRC_LTPASSLError;
-	    }
+        cipherV2 = EVP_get_cipherbyname( LTPA2_CIPHER);
+        if (NULL == cipherV2) {
+            TRACE(1, "EVP_get_cipherbyname error\n");
+            ism_common_setError(ISMRC_LTPASSLError);
+            return ISMRC_LTPASSLError;
+        }
     }
 
     f = fopen(keyfile_path, "r");
@@ -1541,11 +1548,11 @@ XAPI int ism_security_ltpaReadKeyfile(
     ism_security_ltpaQuoteString(keybuf, &escRealm);
     ism_common_free(ism_memory_admin_misc,keybuf);
 
-	int ltpaKeySize = (int)sizeof(ismLTPA_t) + desKeyLen+1;
+    int ltpaKeySize = (int)sizeof(ismLTPA_t) + desKeyLen+1;
     *ltpaKey = (ismLTPA_t *) ism_common_calloc(ISM_MEM_PROBE(ism_memory_admin_misc,172),1,ltpaKeySize);
 
-	char *des_keyPtr = (char *)((*ltpaKey) + 1);
-	memcpy(des_keyPtr, desKey, desKeyLen);
+    char *des_keyPtr = (char *)((*ltpaKey) + 1);
+    memcpy(des_keyPtr, desKey, desKeyLen);
     des_keyPtr[desKeyLen]='\0';
     (*ltpaKey)->des_key =(void *) des_keyPtr;
     
@@ -1673,7 +1680,7 @@ XAPI int ism_security_ltpaV1DecodeToken(
     }
 
     if ( *expiration == 0 ) {
-    	/* set expiration time from token */
+        /* set expiration time from token */
         *expiration = exptime/1000;
         TRACE(9, "Token expiration time:%ld   Current Server Time:%ld\n", *expiration, time(NULL));
     }

--- a/server_build/build_pkg.sh
+++ b/server_build/build_pkg.sh
@@ -259,7 +259,7 @@ function bld_imabridge_rpm {
     sed -i 's/Release:.*/Release: '$RPM_RELEASE/ $RPMBUILD_ROOT_BRIDGE_EL/SPECS/imamqttbridge.spec
 
     #Delete any rpms from older builds that we don't want included
-    rm $BRIDGE_RPMBUILD_DIR/${LINUXDISTRO_FULL}/rpmbuild/RPMS/x86_64/${BRIDGE_NAME}*.rpm
+    rm -f $BRIDGE_RPMBUILD_DIR/${LINUXDISTRO_FULL}/rpmbuild/RPMS/x86_64/${BRIDGE_NAME}*.rpm
     
     # start rpm build
     cd $RPMBUILD_ROOT_BRIDGE_EL/SPECS
@@ -294,7 +294,7 @@ function bld_imabridge_rpm {
         dos2unix ${BUILD_ROOT}/server_build/docker_build/imamqttbridge-sles.spec
         cp ${BUILD_ROOT}/server_build/docker_build/imamqttbridge-sles.spec $RPMBUILD_ROOT_BRIDGE_SLES/SPECS/imamqttbridge-sles.spec
         sed -i 's/Release:.*/Release: '$RPM_RELEASE/ $RPMBUILD_ROOT_BRIDGE_SLES/SPECS/imamqttbridge-sles.spec
-        rm $BRIDGE_RPMBUILD_DIR/sles/rpmbuild/RPMS/x86_64/${BRIDGE_NAME}*.rpm
+        rm -f $BRIDGE_RPMBUILD_DIR/sles/rpmbuild/RPMS/x86_64/${BRIDGE_NAME}*.rpm
         cd $RPMBUILD_ROOT_BRIDGE_SLES/SPECS
         QA_RPATHS=$(( 0x0002|0x0004|0x0008)) rpmbuild --quiet -bb --buildroot $RPMBUILD_ROOT_BRIDGE_SLES/BUILDROOT imamqttbridge-sles.spec
         mkdir -p $BRIDGE_RPMBUILD_DIR/sles/temp
@@ -628,7 +628,7 @@ function rpmbuild_server {
     fi
     
     # Delete any old server rpms from earlier builds we don't want included
-    rm $IMASERVER_RPMBUILD_DIR/${LINUXDISTRO_FULL}/rpmbuild/RPMS/x86_64/${IMASERVER_NAME}*.rpm
+    rm -f $IMASERVER_RPMBUILD_DIR/${LINUXDISTRO_FULL}/rpmbuild/RPMS/x86_64/${IMASERVER_NAME}*.rpm
 
     # start rpm build
     cd $RPMBUILD_ROOT_EL/SPECS
@@ -666,7 +666,7 @@ function rpmbuild_server {
         sed -i 's/Release:.*/Release: '$RPM_RELEASE/ $RPMBUILD_ROOT_SLES/SPECS/imaserver-sles.spec
         cd $RPMBUILD_ROOT_SLES/SPECS
         # Delete any old server rpms from earlier builds we don't want included
-        rm $IMASERVER_RPMBUILD_DIR/sles/rpmbuild/RPMS/x86_64/${IMASERVER_NAME}*.rpm
+        rm -f $IMASERVER_RPMBUILD_DIR/sles/rpmbuild/RPMS/x86_64/${IMASERVER_NAME}*.rpm
 
         QA_RPATHS=$(( 0x0002|0x0004|0x0008)) rpmbuild --quiet -bb --buildroot $RPMBUILD_ROOT_SLES/BUILDROOT imaserver-sles.spec
         mkdir -p $IMASERVER_RPMBUILD_DIR/sles/temp
@@ -749,7 +749,7 @@ function bld_imagui_rpm {
     sed -i 's/Release:.*/Release: '$RPM_RELEASE/ $RPMBUILD_ROOT_WEBUI_EL/SPECS/imawebui.spec
 
     # Delete any old imawebui rpms from earlier builds we don't want included
-    rm $IMAGUI_RPMBUILD_DIR/${LINUXDISTRO_FULL}/rpmbuild/RPMS/x86_64/${IMAGUI_NAME}*.rpm
+    rm -f $IMAGUI_RPMBUILD_DIR/${LINUXDISTRO_FULL}/rpmbuild/RPMS/x86_64/${IMAGUI_NAME}*.rpm
 
     # start rpm build
     cd $RPMBUILD_ROOT_WEBUI_EL/SPECS
@@ -782,7 +782,7 @@ function bld_imagui_rpm {
         cp ${BUILD_ROOT}/server_build/docker_build/imawebui-sles.spec $RPMBUILD_ROOT_WEBUI_SLES/SPECS
         sed -i 's/Release:.*/Release: '$RPM_RELEASE/ $RPMBUILD_ROOT_WEBUI_SLES/SPECS/imawebui-sles.spec
         # Delete any old webui rpms from earlier builds we don't want included
-        rm $IMAGUI_RPMBUILD_DIR/sles/rpmbuild/RPMS/x86_64/${IMAGUI_NAME}*.rpm
+        rm -f $IMAGUI_RPMBUILD_DIR/sles/rpmbuild/RPMS/x86_64/${IMAGUI_NAME}*.rpm
 
         cd $RPMBUILD_ROOT_WEBUI_SLES/SPECS
         QA_RPATHS=$(( 0x0002|0x0004|0x0008)) rpmbuild --quiet -bb --buildroot $RPMBUILD_ROOT_WEBUI_SLES/BUILDROOT imawebui-sles.spec
@@ -901,7 +901,7 @@ function bld_imaproxy_rpm {
     sed -i 's/Release:.*/Release: '$RPM_RELEASE/ $RPMBUILD_ROOT_PROXY/SPECS/imaproxy.spec
 
     # Delete any old proxy rpms from earlier builds we don't want included
-    rm $PROXY_RPMBUILD_DIR/${LINUXDISTRO_FULL}/rpmbuild/RPMS/x86_64/${PROXY_NAME}*.rpm
+    rm -f $PROXY_RPMBUILD_DIR/${LINUXDISTRO_FULL}/rpmbuild/RPMS/x86_64/${PROXY_NAME}*.rpm
 
     # start rpm build
     cd $RPMBUILD_ROOT_PROXY/SPECS

--- a/server_build/build_pkg.sh
+++ b/server_build/build_pkg.sh
@@ -258,6 +258,9 @@ function bld_imabridge_rpm {
     # Change Version and Release in SPEC file
     sed -i 's/Release:.*/Release: '$RPM_RELEASE/ $RPMBUILD_ROOT_BRIDGE_EL/SPECS/imamqttbridge.spec
 
+    #Delete any rpms from older builds that we don't want included
+    rm $BRIDGE_RPMBUILD_DIR/${LINUXDISTRO_FULL}/rpmbuild/RPMS/x86_64/${BRIDGE_NAME}*.rpm
+    
     # start rpm build
     cd $RPMBUILD_ROOT_BRIDGE_EL/SPECS
     QA_RPATHS=$(( 0x0002|0x0004|0x0008)) rpmbuild --quiet -bb --buildroot $RPMBUILD_ROOT_BRIDGE_EL/BUILDROOT imamqttbridge.spec
@@ -291,6 +294,7 @@ function bld_imabridge_rpm {
         dos2unix ${BUILD_ROOT}/server_build/docker_build/imamqttbridge-sles.spec
         cp ${BUILD_ROOT}/server_build/docker_build/imamqttbridge-sles.spec $RPMBUILD_ROOT_BRIDGE_SLES/SPECS/imamqttbridge-sles.spec
         sed -i 's/Release:.*/Release: '$RPM_RELEASE/ $RPMBUILD_ROOT_BRIDGE_SLES/SPECS/imamqttbridge-sles.spec
+        rm $BRIDGE_RPMBUILD_DIR/sles/rpmbuild/RPMS/x86_64/${BRIDGE_NAME}*.rpm
         cd $RPMBUILD_ROOT_BRIDGE_SLES/SPECS
         QA_RPATHS=$(( 0x0002|0x0004|0x0008)) rpmbuild --quiet -bb --buildroot $RPMBUILD_ROOT_BRIDGE_SLES/BUILDROOT imamqttbridge-sles.spec
         mkdir -p $BRIDGE_RPMBUILD_DIR/sles/temp
@@ -622,6 +626,9 @@ function rpmbuild_server {
     if [ "$SHIP_BOOST" == "yes" ] ; then
         sed -i -E 's/^Requires: (.*)boost,(.*)/Requires: \1\2/' $RPMBUILD_ROOT_EL/SPECS/imaserver.spec
     fi
+    
+    # Delete any old server rpms from earlier builds we don't want included
+    rm $IMASERVER_RPMBUILD_DIR/${LINUXDISTRO_FULL}/rpmbuild/RPMS/x86_64/${IMASERVER_NAME}*.rpm
 
     # start rpm build
     cd $RPMBUILD_ROOT_EL/SPECS
@@ -658,6 +665,9 @@ function rpmbuild_server {
         cp ${BUILD_ROOT}/server_build/docker_build/imaserver-sles.spec $RPMBUILD_ROOT_SLES/SPECS/imaserver-sles.spec
         sed -i 's/Release:.*/Release: '$RPM_RELEASE/ $RPMBUILD_ROOT_SLES/SPECS/imaserver-sles.spec
         cd $RPMBUILD_ROOT_SLES/SPECS
+        # Delete any old server rpms from earlier builds we don't want included
+        rm $IMASERVER_RPMBUILD_DIR/sles/rpmbuild/RPMS/x86_64/${IMASERVER_NAME}*.rpm
+
         QA_RPATHS=$(( 0x0002|0x0004|0x0008)) rpmbuild --quiet -bb --buildroot $RPMBUILD_ROOT_SLES/BUILDROOT imaserver-sles.spec
         mkdir -p $IMASERVER_RPMBUILD_DIR/sles/temp
         cp --no-preserve=ownership $IMASERVER_RPMBUILD_DIR/sles/rpmbuild/RPMS/x86_64/${IMASERVER_NAME}*.rpm $IMASERVER_RPMBUILD_DIR/sles/temp/${IMASERVER_NAME}-${ISM_VERSION_ID}-${RPM_BUILD_LABEL}.sle.x86_64.rpm
@@ -738,6 +748,9 @@ function bld_imagui_rpm {
     # Change Version and Release in SPEC file
     sed -i 's/Release:.*/Release: '$RPM_RELEASE/ $RPMBUILD_ROOT_WEBUI_EL/SPECS/imawebui.spec
 
+    # Delete any old imawebui rpms from earlier builds we don't want included
+    rm $IMAGUI_RPMBUILD_DIR/${LINUXDISTRO_FULL}/rpmbuild/RPMS/x86_64/${IMAGUI_NAME}*.rpm
+
     # start rpm build
     cd $RPMBUILD_ROOT_WEBUI_EL/SPECS
     QA_RPATHS=$(( 0x0002|0x0004|0x0008)) rpmbuild --quiet -bb --buildroot $RPMBUILD_ROOT_WEBUI_EL/BUILDROOT imawebui.spec
@@ -768,6 +781,9 @@ function bld_imagui_rpm {
         dos2unix ${BUILD_ROOT}/server_build/docker_build/imawebui-sles.spec
         cp ${BUILD_ROOT}/server_build/docker_build/imawebui-sles.spec $RPMBUILD_ROOT_WEBUI_SLES/SPECS
         sed -i 's/Release:.*/Release: '$RPM_RELEASE/ $RPMBUILD_ROOT_WEBUI_SLES/SPECS/imawebui-sles.spec
+        # Delete any old webui rpms from earlier builds we don't want included
+        rm $IMAGUI_RPMBUILD_DIR/sles/rpmbuild/RPMS/x86_64/${IMAGUI_NAME}*.rpm
+
         cd $RPMBUILD_ROOT_WEBUI_SLES/SPECS
         QA_RPATHS=$(( 0x0002|0x0004|0x0008)) rpmbuild --quiet -bb --buildroot $RPMBUILD_ROOT_WEBUI_SLES/BUILDROOT imawebui-sles.spec
         mkdir -p $IMAGUI_RPMBUILD_DIR/sles/temp
@@ -883,6 +899,9 @@ function bld_imaproxy_rpm {
 
     # Change Version and Release in SPEC file
     sed -i 's/Release:.*/Release: '$RPM_RELEASE/ $RPMBUILD_ROOT_PROXY/SPECS/imaproxy.spec
+
+    # Delete any old proxy rpms from earlier builds we don't want included
+    rm $PROXY_RPMBUILD_DIR/${LINUXDISTRO_FULL}/rpmbuild/RPMS/x86_64/${PROXY_NAME}*.rpm
 
     # start rpm build
     cd $RPMBUILD_ROOT_PROXY/SPECS

--- a/server_build/buildcontainer/Jenkinsfile.distro
+++ b/server_build/buildcontainer/Jenkinsfile.distro
@@ -6,7 +6,7 @@ pipeline {
         //Annoyingly the jobs in jenkins specify a default value as well, so when changing default values below, change them 
         //in any relevant jobs in the jenkins webui as well 
         gitParameter branchFilter: 'origin/(.*)', defaultValue: 'master', name: 'branchName', type: 'PT_BRANCH'
-        choice(name: 'distro', choices: ['centos7','alma8','fedora'], description: 'Linux distribution to build on')
+        choice(name: 'distro', choices: ['centos7','alma8','alma9','fedora'], description: 'Linux distribution to build on')
         string(name: 'buildId',    defaultValue: '',   description: 'Build Identifier to ensure build can be easily identified (set blank to autogenerate - default)')
         string(name: 'buildcontainerVersion', defaultValue: '1.0.0.1', description: 'Version of the amlen-build-(distro) container to use to do the build')
     }

--- a/server_build/buildcontainer/build.sh
+++ b/server_build/buildcontainer/build.sh
@@ -11,7 +11,20 @@ export DEPS_HOME=/deps
 export USE_REAL_TRANSLATIONS=true
 export SLESNORPMS=yes
 export IMASERVER_BASE_DIR=$BROOT/rpmtree
-export JAVA_HOME=/etc/alternatives/java_sdk_1.8.0
+
+if [ -z "${JAVA_HOME}" ]; then
+    if [ -d "/etc/alternatives/java_sdk_11" ]; then
+        export JAVA_HOME=/etc/alternatives/java_sdk_11
+    elif [ -d "/etc/alternatives/java_sdk_1.8.0" ]; then
+        export JAVA_HOME=/etc/alternatives/java_sdk_1.8.0
+    elif [ -d "/etc/alternatives/java_sdk" ]; then
+        export JAVA_HOME=/etc/alternatives/java_sdk
+    else
+        echo "build.sh: Can't guess java sdk location, please set JAVA_HOME"
+        exit 10
+    fi
+fi
+echo "JAVA_HOME is set to ${JAVA_HOME}"
 export PATH=$JAVA_HOME/bin:$PATH
 
 #Set up a home directory we can write to (for rpmbuild)

--- a/server_build/buildcontainer/build.sh
+++ b/server_build/buildcontainer/build.sh
@@ -12,6 +12,7 @@ export USE_REAL_TRANSLATIONS=true
 export SLESNORPMS=yes
 export IMASERVER_BASE_DIR=$BROOT/rpmtree
 export JAVA_HOME=/etc/alternatives/java_sdk_1.8.0
+export PATH=$JAVA_HOME/bin:$PATH
 
 #Set up a home directory we can write to (for rpmbuild)
 if [ "${HOME}" == "/" ]; then 

--- a/server_build/buildcontainer/jenkins.buildalltier1
+++ b/server_build/buildcontainer/jenkins.buildalltier1
@@ -56,8 +56,14 @@ spec:
                              string(name: 'branchName', value: String.valueOf(branchName)),
                              string(name: 'buildId', value: String.valueOf(env.BUILD_LABEL)), 
                              string(name: 'buildcontainerVersion', value: buildcontainerVersion),
-                             string(name: 'distro', value: "alma8")]
-                
+                             string(name: 'distro', value: "alma8")]                
+
+                    build job: 'SingleBranchBuild_ChooseDistro', parameters: [
+                             string(name: 'branchName', value: String.valueOf(branchName)),
+                             string(name: 'buildId', value: String.valueOf(env.BUILD_LABEL)), 
+                             string(name: 'buildcontainerVersion', value: buildcontainerVersion),
+                             string(name: 'distro', value: "alma9")]
+
                     build job: 'SingleBranchBuild_ChooseDistro', parameters: [
                              string(name: 'branchName', value: String.valueOf(branchName)),
                              string(name: 'buildId', value: String.valueOf(env.BUILD_LABEL)),

--- a/server_cluster/src/MCP_Routing/Util/src/city_c.c
+++ b/server_cluster/src/MCP_Routing/Util/src/city_c.c
@@ -481,136 +481,137 @@ uint128 CityHash128(const char *s, size_t len) {
                           uint128i(Fetch64(s), Fetch64(s + 8) + k0)) :
       CityHash128WithSeed(s, len, uint128i(k0, k1));
 }
-
-#ifdef __SSE4_2__
-#include <citycrc_c.h>
-#include <nmmintrin.h>
-
-// Requires len >= 240.
-static void CityHashCrc256Long(const char *s, size_t len,
-                               uint32 seed, uint64 *result) {
-  uint64 a = Fetch64(s + 56) + k0;
-  uint64 b = Fetch64(s + 96) + k0;
-  uint64 c = result[0] = HashLen16(b, len);
-  uint64 d = result[1] = Fetch64(s + 120) * k0 + len;
-  uint64 e = Fetch64(s + 184) + seed;
-  uint64 f = 0;
-  uint64 g = 0;
-  uint64 h = c + d;
-  uint64 x = seed;
-  uint64 y = 0;
-  uint64 z = 0;
-
-  // 240 bytes of input per iter.
-  size_t iters = len / 240;
-  len -= iters * 240;
-  do {
-#undef CHUNK
-#define CHUNK(r)                                \
-    PERMUTE64(x, z, y);                          \
-    b += Fetch64(s);                            \
-    c += Fetch64(s + 8);                        \
-    d += Fetch64(s + 16);                       \
-    e += Fetch64(s + 24);                       \
-    f += Fetch64(s + 32);                       \
-    a += b;                                     \
-    h += f;                                     \
-    b += c;                                     \
-    f += d;                                     \
-    g += e;                                     \
-    e += z;                                     \
-    g += x;                                     \
-    z = _mm_crc32_u64(z, b + g);                \
-    y = _mm_crc32_u64(y, e + h);                \
-    x = _mm_crc32_u64(x, f + a);                \
-    e = Rotate(e, r);                           \
-    c += e;                                     \
-    s += 40
-
-    CHUNK(0) ; PERMUTE64(a, h, c);
-    CHUNK(33); PERMUTE64(a, h, f);
-    CHUNK(0) ; PERMUTE64(b, h, f);
-    CHUNK(42); PERMUTE64(b, h, d);
-    CHUNK(0) ; PERMUTE64(b, h, e);
-    CHUNK(33); PERMUTE64(a, h, e);
-  } while (--iters > 0);
-
-  while (len >= 40) {
-    CHUNK(29);
-    e ^= Rotate(a, 20);
-    h += Rotate(b, 30);
-    g ^= Rotate(c, 40);
-    f += Rotate(d, 34);
-    PERMUTE64(c, h, g);
-    len -= 40;
-  }
-  if (len > 0) {
-    s = s + len - 40;
-    CHUNK(33);
-    e ^= Rotate(a, 43);
-    h += Rotate(b, 42);
-    g ^= Rotate(c, 41);
-    f += Rotate(d, 40);
-  }
-  result[0] ^= h;
-  result[1] ^= g;
-  g += h;
-  a = HashLen16(a, g + z);
-  x += y << 32;
-  b += x;
-  c = HashLen16(c, z) + h;
-  d = HashLen16(d, e + result[0]);
-  g += e;
-  h += HashLen16(x, f);
-  e = HashLen16(a, d) + g;
-  z = HashLen16(b, c) + a;
-  y = HashLen16(g, h) + c;
-  result[0] = e + z + y + x;
-  a = ShiftMix((a + y) * k0) * k0 + b;
-  result[1] += a + result[0];
-  a = ShiftMix(a * k0) * k0 + c;
-  result[2] = a + result[1];
-  a = ShiftMix((a + e) * k0) * k0;
-  result[3] = a + result[2];
-}
-
-// Requires len < 240.
-static void CityHashCrc256Short(const char *s, size_t len, uint64 *result) {
-  char buf[240];
-  memcpy(buf, s, len);
-  memset(buf + len, 0, 240 - len);
-  CityHashCrc256Long(buf, 240, ~(uint32)(len), result);
-}
-
-void CityHashCrc256(const char *s, size_t len, uint64 *result) {
-  if (LIKELY(len >= 240)) {
-    CityHashCrc256Long(s, len, 0, result);
-  } else {
-    CityHashCrc256Short(s, len, result);
-  }
-}
-
-uint128 CityHashCrc128WithSeed(const char *s, size_t len, uint128 seed) {
-  if (len <= 900) {
-    return CityHash128WithSeed(s, len, seed);
-  } else {
-    uint64 result[4];
-    CityHashCrc256(s, len, result);
-    uint64 u = Uint128High64(seed) + result[0];
-    uint64 v = Uint128Low64(seed) + result[1];
-    return uint128i(HashLen16(u, v + result[2]),
-                    HashLen16(Rotate(v, 32), u * k0 + result[3]));
-  }
-}
-
-uint128 CityHashCrc128(const char *s, size_t len) {
-  if (len <= 900) {
-    return CityHash128(s, len);
-  } else {
-    uint64 result[4];
-    CityHashCrc256(s, len, result);
-    return uint128i(result[2], result[3]);
-  }
-}
-
-#endif
+//We (Amlen) don't use the variants that require  __SSE4_2__
+// 
+// #ifdef __SSE4_2__
+// #include <citycrc_c.h>
+// #include <nmmintrin.h>
+// 
+// // Requires len >= 240.
+// static void CityHashCrc256Long(const char *s, size_t len,
+//                                uint32 seed, uint64 *result) {
+//   uint64 a = Fetch64(s + 56) + k0;
+//   uint64 b = Fetch64(s + 96) + k0;
+//   uint64 c = result[0] = HashLen16(b, len);
+//   uint64 d = result[1] = Fetch64(s + 120) * k0 + len;
+//   uint64 e = Fetch64(s + 184) + seed;
+//   uint64 f = 0;
+//   uint64 g = 0;
+//   uint64 h = c + d;
+//   uint64 x = seed;
+//   uint64 y = 0;
+//   uint64 z = 0;
+// 
+//   // 240 bytes of input per iter.
+//   size_t iters = len / 240;
+//   len -= iters * 240;
+//   do {
+// #undef CHUNK
+// #define CHUNK(r)                                \
+//     PERMUTE64(x, z, y);                          \
+//     b += Fetch64(s);                            \
+//     c += Fetch64(s + 8);                        \
+//     d += Fetch64(s + 16);                       \
+//     e += Fetch64(s + 24);                       \
+//     f += Fetch64(s + 32);                       \
+//     a += b;                                     \
+//     h += f;                                     \
+//     b += c;                                     \
+//     f += d;                                     \
+//     g += e;                                     \
+//     e += z;                                     \
+//     g += x;                                     \
+//     z = _mm_crc32_u64(z, b + g);                \
+//     y = _mm_crc32_u64(y, e + h);                \
+//     x = _mm_crc32_u64(x, f + a);                \
+//     e = Rotate(e, r);                           \
+//     c += e;                                     \
+//     s += 40
+// 
+//     CHUNK(0) ; PERMUTE64(a, h, c);
+//     CHUNK(33); PERMUTE64(a, h, f);
+//     CHUNK(0) ; PERMUTE64(b, h, f);
+//     CHUNK(42); PERMUTE64(b, h, d);
+//     CHUNK(0) ; PERMUTE64(b, h, e);
+//     CHUNK(33); PERMUTE64(a, h, e);
+//   } while (--iters > 0);
+// 
+//   while (len >= 40) {
+//     CHUNK(29);
+//     e ^= Rotate(a, 20);
+//     h += Rotate(b, 30);
+//     g ^= Rotate(c, 40);
+//     f += Rotate(d, 34);
+//     PERMUTE64(c, h, g);
+//     len -= 40;
+//   }
+//   if (len > 0) {
+//     s = s + len - 40;
+//     CHUNK(33);
+//     e ^= Rotate(a, 43);
+//     h += Rotate(b, 42);
+//     g ^= Rotate(c, 41);
+//     f += Rotate(d, 40);
+//   }
+//   result[0] ^= h;
+//   result[1] ^= g;
+//   g += h;
+//   a = HashLen16(a, g + z);
+//   x += y << 32;
+//   b += x;
+//   c = HashLen16(c, z) + h;
+//   d = HashLen16(d, e + result[0]);
+//   g += e;
+//   h += HashLen16(x, f);
+//   e = HashLen16(a, d) + g;
+//   z = HashLen16(b, c) + a;
+//   y = HashLen16(g, h) + c;
+//   result[0] = e + z + y + x;
+//   a = ShiftMix((a + y) * k0) * k0 + b;
+//   result[1] += a + result[0];
+//   a = ShiftMix(a * k0) * k0 + c;
+//   result[2] = a + result[1];
+//   a = ShiftMix((a + e) * k0) * k0;
+//   result[3] = a + result[2];
+// }
+// 
+// // Requires len < 240.
+// static void CityHashCrc256Short(const char *s, size_t len, uint64 *result) {
+//   char buf[240];
+//   memcpy(buf, s, len);
+//   memset(buf + len, 0, 240 - len);
+//   CityHashCrc256Long(buf, 240, ~(uint32)(len), result);
+// }
+// 
+// void CityHashCrc256(const char *s, size_t len, uint64 *result) {
+//   if (LIKELY(len >= 240)) {
+//     CityHashCrc256Long(s, len, 0, result);
+//   } else {
+//     CityHashCrc256Short(s, len, result);
+//   }
+// }
+// 
+// uint128 CityHashCrc128WithSeed(const char *s, size_t len, uint128 seed) {
+//   if (len <= 900) {
+//     return CityHash128WithSeed(s, len, seed);
+//   } else {
+//     uint64 result[4];
+//     CityHashCrc256(s, len, result);
+//     uint64 u = Uint128High64(seed) + result[0];
+//     uint64 v = Uint128Low64(seed) + result[1];
+//     return uint128i(HashLen16(u, v + result[2]),
+//                     HashLen16(Rotate(v, 32), u * k0 + result[3]));
+//   }
+// }
+// 
+// uint128 CityHashCrc128(const char *s, size_t len) {
+//   if (len <= 900) {
+//     return CityHash128(s, len);
+//   } else {
+//     uint64 result[4];
+//     CityHashCrc256(s, len, result);
+//     return uint128i(result[2], result[3]);
+//   }
+// }
+// 
+// #endif

--- a/server_plugin/build.xml
+++ b/server_plugin/build.xml
@@ -13,7 +13,7 @@
 #
 -->
 
-<project name="server_plugin" default="build_server_plugin">
+<project name="server_plugin" default="build_server_plugin" xmlns:if="ant:if" xmlns:unless="ant:unless">
 	<property environment="env" />
 	<property name="server.plugin.dir" location="." />
 	<property name="server.plugin.src.dir" location="${server.plugin.dir}/src" />
@@ -25,9 +25,6 @@
 	<property name="server.tmstool.dir" value="${server.plugin.dir}/../server_tmsmsgtool"/>
 	<property name="server.common.dir" value="${server.plugin.dir}/../server_ship"/>
 	<property name="server.common.lib.dir" value="${server.common.dir}/../server_ship/lib"/>
-
-	<!-- Load contrib library -->
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 
     <available file="${server.plugin.rpx.dir}" type="dir" property="rpx.path.exists" />
     <available file="${server.common.dir}/msgcat" type="dir" property="msgcat.path.exists" />
@@ -188,29 +185,23 @@
 			<equals arg1="${os.name}" arg2="SunOS"/>
 		</condition>
 
-		<if>
-			<isset property="generate_coverage" />
-			<then>
-				<coverage destfile="${server.plugin.bin.dir}/jacoco.exec">
-					<junit printsummary="no" haltonfailure="false" haltonerror="false" jvm="java" showoutput="yes" fork="true" forkmode="once">
-						<jvmarg value="${jvmargadd_1}" />
-						<classpath refid="test.classpath" />
-						<formatter type="xml" />
-						<formatter type="plain" usefile="no" />
-						<test name="com.ibm.ima.plugin.unittest.AllTests" fork="yes" todir="${test.data.dir}"/>
-					</junit>
-				</coverage>
-			</then>
-			<else>
-				<junit printsummary="no" haltonfailure="true" haltonerror="true" jvm="java" showoutput="yes">
-					<jvmarg value="${jvmargadd_1}" />
-					<classpath refid="test.classpath" />
-					<formatter type="xml" />
-					<formatter type="plain" usefile="no" />
-					<test name="com.ibm.ima.plugin.unittest.AllTests" fork="yes" todir="${test.data.dir}"/>
-				</junit>
-			</else>
-		</if>
+		<coverage destfile="${server.plugin.bin.dir}/jacoco.exec" if:set="generate_coverage">
+			<junit printsummary="no" haltonfailure="false" haltonerror="false" jvm="java" showoutput="yes" fork="true" forkmode="once">
+				<jvmarg value="${jvmargadd_1}" />
+				<classpath refid="test.classpath" />
+				<formatter type="xml" />
+				<formatter type="plain" usefile="no" />
+				<test name="com.ibm.ima.plugin.unittest.AllTests" fork="yes" todir="${test.data.dir}"/>
+			</junit>
+		</coverage>
+
+		<junit printsummary="no" haltonfailure="true" haltonerror="true" jvm="java" showoutput="yes" unless:set="generate_coverage">
+			<jvmarg value="${jvmargadd_1}" />
+			<classpath refid="test.classpath" />
+			<formatter type="xml" />
+			<formatter type="plain" usefile="no" />
+			<test name="com.ibm.ima.plugin.unittest.AllTests" fork="yes" todir="${test.data.dir}"/>
+		</junit>
 
 		<!-- HTML report for the unit tests -->
 		<junitreport todir="${test.data.dir}" >
@@ -236,27 +227,23 @@
 	<!-- Executing RPX tool for pseudo translation-->
 
 	<target name="NWays_mock" if="rpx.path.exists" unless="translations.present" description="Runs RPX class to do pseudo translation">
-		<if>
-	    	<equals arg1="${msgcat.path.exists}" arg2="true"/>
-    	<then>
-			<!-- Classpath for RPX -->
-			<path id="rpx.specific.classpath">
-		    	<pathelement location="rpx.jar"/>
-			    <fileset dir="${server.plugin.rpx.dir}">
-			       <include name="**/*.jar"/>
-			    </fileset>
-			</path>
+		<!-- Classpath for RPX -->
+		<path id="rpx.specific.classpath" if:set="msgcat.path.exists">
+			<pathelement location="rpx.jar"/>
+			<fileset dir="${server.plugin.rpx.dir}">
+				<include name="**/*.jar"/>
+			</fileset>
+		</path>
 
-			<taskdef name="nways" classname="com.ibm.rpx.ant.Nw" classpathref="rpx.specific.classpath"/>
+		<taskdef name="nways" classname="com.ibm.rpx.ant.Nw" classpathref="rpx.specific.classpath"/>
 
-			<echo message="Running RPX"/>
-			<nways classpath="${server.plugin.rpx.dir};${server.plugin.rpx.dir}\rpx.jar;${ant.home}/lib/ant.jar" ways="fr de ja zh zh_TW" >
-				<fileset dir="${server.common.dir}/msgcat/com/ibm/ima/plugin/msgcatalog/">
-					<include name="IsmpluginListResourceBundle.java"/>
-				</fileset>
-			</nways>
-		</then>
-		</if>
+		<echo message="Running RPX" if:set="msgcat.path.exists"/>
+		<nways classpath="${server.plugin.rpx.dir};${server.plugin.rpx.dir}\rpx.jar;${ant.home}/lib/ant.jar" ways="fr de ja zh zh_TW"
+			 if:set="msgcat.path.exists" >
+			<fileset dir="${server.common.dir}/msgcat/com/ibm/ima/plugin/msgcatalog/">
+				<include name="IsmpluginListResourceBundle.java"/>
+			</fileset>
+		</nways>
 	</target>
 
     <!-- Initialize the build environment -->


### PR DESCRIPTION
This has miscellaneous changes to allow us to work on RHEL9 (actually the clone AlmaLinux 9):
* More cases that relied on ant-contrib that doesn't come with alma9
* Build with Java11 (previously we insisted on Java8)
* change to decrypting LTPA tokens when we were making some dodgy assumptions about buffers that aren't valid on openssl 3.0 (which is what is used in Alma 9)