### PR TITLE
Update downloads page and fixes/improvements for distro build all

### DIFF
--- a/server_build/buildcontainer/Jenkinsfile.distro
+++ b/server_build/buildcontainer/Jenkinsfile.distro
@@ -8,7 +8,7 @@ pipeline {
         gitParameter branchFilter: 'origin/(.*)', defaultValue: 'master', name: 'branchName', type: 'PT_BRANCH'
         choice(name: 'distro', choices: ['centos7','alma8','fedora'], description: 'Linux distribution to build on')
         string(name: 'buildId',    defaultValue: '',   description: 'Build Identifier to ensure build can be easily identified (set blank to autogenerate - default)')
-        string(name: 'buildcontainerVersion', defaultValue: '1.0.0.1', description: 'Version of the amlen-build-(distro) container to use to do the build')
+        string(name: 'buildcontainerVersion', defaultValue: '1.0.0.2', description: 'Version of the amlen-build-(distro) container to use to do the build')
     }
 
   agent {
@@ -62,6 +62,7 @@ spec:
                         if (env.BUILD_LABEL == null ) {
                             env.BUILD_LABEL = sh(script: "date +%Y%m%d-%H%M", returnStdout: true).toString().trim() +"_eclipse${distro}"
                         }
+                        currentBuild.displayName ="${currentBuild.number}-${distro}"
                     }
                     echo "In Init, BUILD_LABEL is ${env.BUILD_LABEL}"    
                 }

--- a/server_build/buildcontainer/jenkins.buildalltier1
+++ b/server_build/buildcontainer/jenkins.buildalltier1
@@ -21,7 +21,7 @@ spec:
     parameters{
         gitParameter branchFilter: 'origin/(.*)', defaultValue: 'master', name: 'branchName', type: 'PT_BRANCH'
         string(name: 'buildId',    defaultValue: '',   description: 'Build Identifier to ensure build can be easily identified (set blank to autogenerate - default)')
-        string(name: 'buildcontainerVersion', defaultValue: '1.0.0.1', description: 'Version of the amlen-build-(distro) container to use to do the build')
+        string(name: 'buildcontainerVersion', defaultValue: '1.0.0.2', description: 'Version of the amlen-build-(distro) container to use to do the build')
     }
     
     stages {
@@ -45,20 +45,20 @@ spec:
                 container('jnlp') {
                     echo "In BuildFanout, BUILD_LABEL is ${env.BUILD_LABEL}"
                     
-                    build job: 'SingleBranchBuild_ChooseDistro', parameters: [
+                    build job: 'Build_SingleBranch_ChooseDistro', parameters: [
                              string(name: 'branchName', value: String.valueOf(branchName)),
                              string(name: 'buildId', value: String.valueOf(env.BUILD_LABEL)),
                              string(name: 'buildcontainerVersion', value: buildcontainerVersion),
                              string(name: 'distro', value: "centos7")
                              ]
 
-                    build job: 'SingleBranchBuild_ChooseDistro', parameters: [
+                    build job: 'Build_SingleBranch_ChooseDistro', parameters: [
                              string(name: 'branchName', value: String.valueOf(branchName)),
                              string(name: 'buildId', value: String.valueOf(env.BUILD_LABEL)), 
                              string(name: 'buildcontainerVersion', value: buildcontainerVersion),
                              string(name: 'distro', value: "alma8")]
                 
-                    build job: 'SingleBranchBuild_ChooseDistro', parameters: [
+                    build job: 'Build_SingleBranch_ChooseDistro', parameters: [
                              string(name: 'branchName', value: String.valueOf(branchName)),
                              string(name: 'buildId', value: String.valueOf(env.BUILD_LABEL)),
                              string(name: 'buildcontainerVersion', value: buildcontainerVersion),

--- a/websites/download/index.html
+++ b/websites/download/index.html
@@ -10,6 +10,7 @@
   <p><a href="https://www.eclipse.org/amlen/">Amlen Home</a></p>
   <p>Releases</p>
   <ul>
+  <li><a href="#1.1">1.1</a></li>
   <li><a href="#1.0">1.0</a></li>
   </ul>
   <p>Other:</p>
@@ -22,7 +23,21 @@
   <div id="maincontent">
      <h1>Eclipse Amlen&trade; Downloads</h1>
      
+     <h3>1.1.0</h3>
+
+     <a name="1.1"/>
+     <a name="1.1.0-alpha"/>
+
+     <p>1.1.0-alpha is now available. A pre-release version containing an ansible based operator.</p>
+     <ul>
+     <li>CentOS7/RHEL7 downloads: <a href="https://www.eclipse.org/downloads/download.php?file=/amlen/releases/1.1.0-alpha/centos7/EclipseAmlenServer-centos7-1.1dev-20220809-1356_eclipsecentos7.tar.gz">Amlen Server 1.1.0-alpha</a>, 
+<a href="https://www.eclipse.org/downloads/download.php?file=/amlen/releases/1.1.0-alpha/centos7/EclipseAmlenWebUI-centos7-1.1dev-20220809-1356_eclipsecentos7.tar.gz">Amlen WebUI 1.1.0-alpha</a>, 
+<a href="https://www.eclipse.org/downloads/download.php?file=/amlen/releases/1.1.0-alpha/centos7/EclipseAmlenBridge-centos7-1.1dev-20220809-1356_eclipsecentos7.tar.gz">Amlen Bridge 1.1.0-alpha</a>, 
+     </ul>
+     
+     <h3>Older Releases</h3>
      <h3>1.0.0.1</h3>
+
      <a name="1.0"></a>
      <a name="1.0.0.1"></a>
      <p>1.0.0.1 is now available. A minor update to 1.0.0.0 with the main differences being fixes to the WebUI.</p>


### PR DESCRIPTION
The ChooseDistro job was renamed so updated the BuildAll job to match
Added the distro to the name of the build in ChooseDistro to make it easier to see what builds we are doing
Updated the download page for the links to the alpha