### PR TITLE
[patch] Add missing dockerfile for alma9 builder & update to Fedora 36

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,4 @@ directory.
 There is a a Docker file and build script that we use to do the build at Eclipse that show downloading
 of the dependencies and setting of the environment variables. There can be found in the 
 [server_build/buildcontainer](server_build/buildcontainer) directory.
+

--- a/server_build/buildcontainer/Dockerfile.alma9
+++ b/server_build/buildcontainer/Dockerfile.alma9
@@ -1,19 +1,19 @@
 
-FROM quay.io/fedora/fedora:36-x86_64 as builder
+FROM quay.io/almalinux/almalinux:9 as builder
 
 ENV DEPS_HOME ${HOME}/deps
 
 RUN mkdir -p ${DEPS_HOME}
 
 RUN dnf -y update && \
+    #Cunit comes from the crb repo (need to install plugins-core for the config manager)
+    dnf -y install dnf-plugins-core && dnf config-manager --set-enabled crb && \
     # Install system tools and build dependencies required to build all releases of MessageGateway/MSProxy
     dnf -y install --nobest gcc gcc-c++ make cmake3 CUnit CUnit-devel junit ant ant-apache-xalan2 ant-junit libxslt && \
     # Install library dependencies (1/2)
     dnf -y install openssl-devel curl-devel openldap-devel net-snmp-devel libicu-devel icu boost-devel && \
     # Install library dependencies (1/2)
     dnf -y install jansson jansson-devel pam-devel curl-devel && \
-    # Install java compiler and runtime
-    dnf -y install java-1.8.0-openjdk-devel java-1.8.0-openjdk &&\
     # Install some tools which developers find useful during basic testing
     dnf -y install less wget vim-enhanced dos2unix bc gdb net-tools openssh-clients bzip2 unzip zip procps && \
     dnf -y install man file which lsof strace python3-devel python3-pip nodejs npm valgrind nc nmap logrotate && \


### PR DESCRIPTION
Adds the Dockerfile used to build the amlen-builder for alma9 (a clone of rhel9) and updates the Fedora builder dockerfile to F36.