### PR TITLE
Update to targetting Java 1.8 and fix some prereq includes

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,3 +47,4 @@ The timing and manner of disclosure is governed by the
 
 Publicly disclosed issues are listed on the
 [Disclosed Vulnerabilities Page](https://www.eclipse.org/security/known.php).
+

--- a/client_jms/build.xml
+++ b/client_jms/build.xml
@@ -188,7 +188,7 @@
 		<replace file="${client.jms.src.dir}/com/ibm/ima/jms/impl/ImaConstants.java" token="VERSION_ID" value="${version.id}" />
 
 
-		<javac source="1.6" target="1.6" srcdir="${client.jms.src.dir}" destdir="${client.jms.bin.dir}" deprecation="no"
+		<javac source="1.8" target="1.8" srcdir="${client.jms.src.dir}" destdir="${client.jms.bin.dir}" deprecation="no"
              includeAntRuntime="no" encoding="utf-8"
              debug="yes" debuglevel="lines,source,vars" optimize="yes">
 			<src path="${client.jms.src.dir}" />
@@ -346,8 +346,8 @@
 		<replace file="${client.jms.test.src.dir}/com/ibm/ima/jms/impl/AllTests.java"
 			token="RUN_PSEUDOLOCALIZED_MESSAGES_TEST"
 			value="${run.pseudolocalized.messages.test}" />
-		<javac source="1.6"
-               target="1.6"
+		<javac source="1.8"
+               target="1.8"
                srcdir="${client.jms.test.src.dir}"
                destdir="${client.jms.junit.dir}"
                includeAntRuntime="no"
@@ -365,8 +365,8 @@
 	<!--Compile the project-->
 	<target name="jms_samples" depends="jms_publish">
 		<!--  Compile the samples classes with no visibility to the internal files -->
-		<javac source="1.6"
-               target="1.6"
+		<javac source="1.8"
+               target="1.8"
                srcdir="${client.jms.samples.src.dir}"
                destdir="${client.jms.samples.bin.dir}"
                deprecation="no"

--- a/client_mqttv3sample_java/build.xml
+++ b/client_mqttv3sample_java/build.xml
@@ -87,7 +87,7 @@
 	<!--Compile the project-->
 	<target name="mqttv3sample_compile" depends="client_mqttv3sample_init">
 		<!--  Compile the samples classes with no visibility to the internal files -->
-		<javac  source="1.6" target="1.6" srcdir="${client.mqttv3sample.java.src.dir}" destdir="${client.mqttv3sample.java.bin.dir}" deprecation="no"
+		<javac  source="1.8" target="1.8" srcdir="${client.mqttv3sample.java.src.dir}" destdir="${client.mqttv3sample.java.bin.dir}" deprecation="no"
              includeAntRuntime="no"
              debug="yes" debuglevel="lines,source,vars" optimize="yes">
 			<src path="${client.mqttv3sample.java.src.dir}" />

--- a/client_plugin/build.xml
+++ b/client_plugin/build.xml
@@ -266,7 +266,7 @@
 		<replace file="${client.plugin.src.dir}/com/ibm/ima/plugin/impl/ImaConstants.java" token="VERSION_ID" value="${version.id}" />
 		-->
 
-		<javac source="1.6" target="1.6" srcdir="${client.plugin.src.dir}" destdir="${client.plugin.bin.dir}" deprecation="no"
+		<javac source="1.8" target="1.8" srcdir="${client.plugin.src.dir}" destdir="${client.plugin.bin.dir}" deprecation="no"
              includeAntRuntime="no" encoding="utf-8"
              debug="yes" debuglevel="lines,source,vars" optimize="yes">
 			<src path="${client.plugin.src.dir}" />
@@ -505,7 +505,7 @@
 
 	<!--  Compile the unit test code  -->
 	<target name="plugin_compile_test" depends="plugin_compile">
-		<javac  source="1.6" target="1.6" srcdir="${client.plugin.test.src.dir}" destdir="${client.plugin.junit.dir}"
+		<javac  source="1.8" target="1.8" srcdir="${client.plugin.test.src.dir}" destdir="${client.plugin.junit.dir}"
                      debug="yes" debuglevel="lines,source,vars" optimize="yes" encoding="utf-8">
          <classpath refid="test.classpath" />
       </javac>
@@ -517,7 +517,7 @@
 	<!--Compile the project-->
 	<target name="plugin_samples" depends="plugin_publish">
 		<!--  Compile the samples classes with no visibility to the internal files -->
-		<javac  source="1.6" target="1.6" srcdir="${client.plugin.samples.src.dir}" destdir="${client.plugin.samples.bin.dir}" deprecation="no"
+		<javac  source="1.8" target="1.8" srcdir="${client.plugin.samples.src.dir}" destdir="${client.plugin.samples.bin.dir}" deprecation="no"
              includeAntRuntime="no" encoding="utf-8"
              debug="yes" debuglevel="lines,source,vars" optimize="yes">
 			<src path="${client.plugin.samples.src.dir}" />

--- a/client_proxy/build.xml
+++ b/client_proxy/build.xml
@@ -101,7 +101,7 @@
 		<!--  Compile the public api classes with no visibility to the internal files -->
 		<javac srcdir="${client.proxy.src.dir}" destdir="${client.proxy.bin.dir}" deprecation="no"
              includeAntRuntime="no" encoding="utf-8"
-             debug="yes" debuglevel="lines,source" optimize="yes" target="1.6" source="1.6">
+             debug="yes" debuglevel="lines,source" optimize="yes" target="1.8" source="1.8">
 			<src path="${client.proxy.src.dir}" />
 			<classpath refid="compile.classpath" />
 		</javac>
@@ -190,7 +190,7 @@
 	<!--  Compile the unit test code  -->
 	<target name="proxy_compile_test" depends="proxy_compile">
 		<javac srcdir="${client.proxy.test.src.dir}" destdir="${client.proxy.junit.dir}" encoding="utf-8"
-                     debug="yes" debuglevel="lines,source" optimize="yes" target="1.6" source="1.6">
+                     debug="yes" debuglevel="lines,source" optimize="yes" target="1.8" source="1.8">
          <classpath refid="test.classpath" />
       </javac>
       <copy todir="${client.proxy.junit.dir}" preservelastmodified="yes">

--- a/client_ra/build.xml
+++ b/client_ra/build.xml
@@ -239,8 +239,8 @@
 
 	<!--  Compile the unit test code  -->
 	<target name="jmsra_compile_test" depends="ra_compile">
-		<javac source="1.6"
-               target="1.6"
+		<javac source="1.8"
+               target="1.8"
                srcdir="${client.ra.test.src.dir}"
                destdir="${client.ra.junit.dir}"
                encoding="utf-8"
@@ -274,7 +274,7 @@
         <replace file="${client.ra.src.dir}/com/ibm/ima/ra/ImaResourceAdapterMetaData.java" token="VERSION_ID" value="${version.id}" />
 
 		<!--  Compile the public api classes with no visibility to the internal files -->
-		<javac source="1.6" target="1.6" srcdir="${client.ra.src.dir}" destdir="${client.ra.bin.dir}" deprecation="no"
+		<javac source="1.8" target="1.8" srcdir="${client.ra.src.dir}" destdir="${client.ra.bin.dir}" deprecation="no"
              includeAntRuntime="no" encoding="utf-8"
              debug="yes" debuglevel="lines,source,vars" optimize="yes">
 			<src path="${client.ra.src.dir}" />

--- a/fvt_MQConnectivity/build.xml
+++ b/fvt_MQConnectivity/build.xml
@@ -100,7 +100,7 @@
 	<!--Compile the project-->
 	<target name="mqconnectivity_compile" depends="fvt_mqconnectivity_init">
 		<!--  Compile the public api classes with no visibility to the internal files -->
-		<javac  source="1.6" target="1.6" srcdir="${fvt.mqconnectivity.src.dir}" destdir="${fvt.mqconnectivity.bin.dir}" deprecation="no"
+		<javac  source="1.8" target="1.8" srcdir="${fvt.mqconnectivity.src.dir}" destdir="${fvt.mqconnectivity.bin.dir}" deprecation="no"
              includeAntRuntime="no"
              debug="yes" debuglevel="lines,source,vars" optimize="yes">
 			<src path="${fvt.mqconnectivity.src.dir}" />

--- a/fvt_MQxrscada/build.xml
+++ b/fvt_MQxrscada/build.xml
@@ -52,7 +52,7 @@
 	</target>
 
 	<target name="compile" depends="init">
-		<javac  source="1.6" target="1.6" srcdir="${src}" destdir="${build}" debug="Yes" deprecation="Yes">
+		<javac  source="1.8" target="1.8" srcdir="${src}" destdir="${build}" debug="Yes" deprecation="Yes">
 	    	<classpath refid="compile.classpath" />
 		</javac>
 		<copy todir="${build}" preservelastmodified="yes">

--- a/server_build/distrobuild/imamqttbridge.spec
+++ b/server_build/distrobuild/imamqttbridge.spec
@@ -26,7 +26,7 @@ Group: Applications/Communications
 Source0: %{sourcename}.zip
 
 BuildRoot: %{_topdir}/tmp/%{name}-%{Version}.${Release}
-BuildRequires: openssl-devel,curl-devel,openldap-devel,net-snmp-devel,libicu-devel,rpm-build,vim-common,gcc,gcc-c++,make,CUnit-devel,junit,ant-contrib,boost-devel,dos2unix,ant,java-11-openjdk-devel,icu,javapackages-local
+BuildRequires: openssl-devel,curl-devel,openldap-devel,net-snmp-devel,libicu-devel,rpm-build,vim-common,gcc,gcc-c++,make,CUnit-devel,junit,boost-devel,dos2unix,ant,java-11-openjdk-devel,icu,javapackages-local
 Requires: gdb, net-tools, openssl, tar, perl, procps >= 3.3.9, libjansson.so.4()(64bit), logrotate, zip, bzip2, unzip
 Obsoletes: IBMIoTMessageSightServer < 6.0
 

--- a/server_build/distrobuild/imasdk.spec
+++ b/server_build/distrobuild/imasdk.spec
@@ -31,7 +31,7 @@ Source0: %{sourcename}.zip
 Source1: imasdk-deps.zip
 
 BuildRoot: %{_topdir}/tmp/%{name}-%{Version}.${Release}
-BuildRequires: libicu-devel,rpm-build,junit,ant-contrib,icu,libxslt,ant-junit,python3,java-devel
+BuildRequires: libicu-devel,rpm-build,junit,icu,libxslt,ant-junit,python3,java-devel,gcc
 #Requires: 
 
 %description

--- a/server_build/distrobuild/imaserver.spec
+++ b/server_build/distrobuild/imaserver.spec
@@ -26,7 +26,7 @@ Group: Applications/Communications
 Source0: %{sourcename}.zip
 
 BuildRoot: %{_topdir}/tmp/%{name}-%{Version}.${Release}
-BuildRequires: openssl-devel,curl-devel,openldap-devel,net-snmp-devel,libicu-devel,rpm-build,vim-common,gcc,gcc-c++,make,CUnit-devel,junit,ant-contrib,boost-devel,dos2unix,ant,java-11-openjdk-devel,icu,javapackages-local,jansson-devel
+BuildRequires: openssl-devel,curl-devel,openldap-devel,net-snmp-devel,libicu-devel,rpm-build,vim-common,gcc,gcc-c++,make,CUnit-devel,junit,boost-devel,dos2unix,ant,java-11-openjdk-devel,icu,javapackages-local,jansson-devel
 Requires: gdb, net-tools, openssl, tar, perl, procps >= 3.3.9, libjansson.so.4()(64bit), logrotate, zip, bzip2, unzip, boost, libicu, net-snmp
 
 %description

--- a/server_build/distrobuild/imawebui.spec
+++ b/server_build/distrobuild/imawebui.spec
@@ -33,7 +33,7 @@ Source0: %{sourcename}.zip
 Source1: imawebui-deps.zip
 
 BuildRoot: %{_topdir}/tmp/%{name}-%{Version}.${Release}
-BuildRequires: rpm-build,junit,ant-contrib,ant,java-11-openjdk-devel,icu,javapackages-tools,dos2unix
+BuildRequires: rpm-build,junit,ant,java-11-openjdk-devel,icu,javapackages-tools,dos2unix
 Requires: net-tools, openldap, openldap-servers, openldap-clients, tar, openssl, procps, which
 Obsoletes: IBMIoTMessageSightWebUI < 6.0
 

--- a/server_build/distrobuild/mqcbridge.spec
+++ b/server_build/distrobuild/mqcbridge.spec
@@ -28,7 +28,7 @@ Source1: 9.2.0.5-IBM-MQC-LinuxX64.tar.gz
 Source2: 9.2.0.5-IBM-MQC-Redist-LinuxX64.tar.gz 
 
 BuildRoot: %{_topdir}/tmp/%{name}-%{Version}.${Release}
-BuildRequires: openssl-devel,curl-devel,openldap-devel,net-snmp-devel,libicu-devel,rpm-build,python3,vim-common,gcc,gcc-c++,make,CUnit-devel,junit,ant-contrib,boost-devel,dos2unix,ant,jansson-devel
+BuildRequires: openssl-devel,curl-devel,openldap-devel,net-snmp-devel,libicu-devel,rpm-build,python3,vim-common,gcc,gcc-c++,make,CUnit-devel,junit,boost-devel,dos2unix,ant,jansson-devel,icu,libxslt
 Requires: gdb, net-tools, openssl, tar, perl, procps >= 3.3.9, libjansson.so.4()(64bit), logrotate, zip, bzip2, unzip, EclipseAmlenServer
 
 %description

--- a/server_build/distrobuild/protocolplugin.spec
+++ b/server_build/distrobuild/protocolplugin.spec
@@ -30,7 +30,7 @@ Group: Applications/Communications
 Source0: %{sourcename}.zip
 
 BuildRoot: %{_topdir}/tmp/%{name}-%{Version}.${Release}
-BuildRequires: junit,ant-contrib,python3,java-devel,icu,libxslt,ant-junit
+BuildRequires: junit,python3,java-devel,icu,libxslt,ant-junit
 Requires:  EclipseAmlenServer
 
 %description

--- a/svt_client_tests/build.xml
+++ b/svt_client_tests/build.xml
@@ -76,7 +76,7 @@
 	<!--Compile the project-->
 	<target name="compile">
 		<!--  Compile the public api classes with no visibility to the internal files -->
-		<javac  source="1.6" target="1.6" srcdir="${src.dir}" destdir="${bin.dir}" deprecation="no"
+		<javac  source="1.8" target="1.8" srcdir="${src.dir}" destdir="${bin.dir}" deprecation="no"
 	             includeAntRuntime="no"
 	             debug="yes" debuglevel="lines,source,vars" optimize="yes">
 			<src path="${src.dir}" />

--- a/testTools_CLI_Utils/build.xml
+++ b/testTools_CLI_Utils/build.xml
@@ -57,7 +57,7 @@
 
 	<!--Compile the project-->
 	<target name="compile" depends="init">
-		<javac  source="1.6" target="1.6" srcdir="${src}" destdir="${build}" debug="Yes" deprecation="Yes">
+		<javac  source="1.8" target="1.8" srcdir="${src}" destdir="${build}" debug="Yes" deprecation="Yes">
 	         <classpath refid="compile.classpath" />
 		</javac>
 		<copy todir="${build}" preservelastmodified="yes">

--- a/testTools_DriverSync/build.xml
+++ b/testTools_DriverSync/build.xml
@@ -43,7 +43,7 @@
 	</target>
 
 	<target name="compile" depends="init">
-		<javac  source="1.6" target="1.6" srcdir="${src}" destdir="${build}" debug="Yes" deprecation="Yes">
+		<javac  source="1.8" target="1.8" srcdir="${src}" destdir="${build}" debug="Yes" deprecation="Yes">
 			</javac>		
 		<copy todir="${build}" preservelastmodified="yes">
 			<fileset dir="${src}" excludes="**/*.java" />

--- a/testTools_JCA/build.xml
+++ b/testTools_JCA/build.xml
@@ -48,8 +48,8 @@
         <echo> ==  Compile jcatests.ejb project ================ </echo>
         <mkdir dir="${jcatests.ejb.bin.dir}/classes" />
         <javac srcdir="${jcatests.ejb.src.dir}"
-        	source="1.6"
-        	target="1.6"
+        	source="1.8"
+        	target="1.8"
             destdir="${jcatests.ejb.bin.dir}/classes"
             deprecation="no"
             includeAntRuntime="no"
@@ -68,8 +68,8 @@
     	<delete dir="${jcatests.ejb.bin.dir}/classes"/>
         <mkdir dir="${jcatests.web.bin.dir}/classes"/>
         <javac srcdir="${jcatests.web.src.dir}"
-        	source="1.6"
-        	target="1.6"
+        	source="1.8"
+        	target="1.8"
             destdir="${jcatests.web.bin.dir}/classes"
             deprecation="no"
             includeAntRuntime="no"

--- a/testTools_JCAra/build.xml
+++ b/testTools_JCAra/build.xml
@@ -103,7 +103,7 @@
     <echo> === Compile Evil RA === </echo>
     <pathconvert property="expanded.compile.classpath" refid="compile.classpath" />
     <echo message="${expanded.compile.classpath}" />
-        <javac source="1.6" target="1.6" srcdir="${evil.ra.src.dir}" destdir="${evil.ra.bin.dir}" deprecation="no"
+        <javac source="1.8" target="1.8" srcdir="${evil.ra.src.dir}" destdir="${evil.ra.bin.dir}" deprecation="no"
            includeAntRuntime="no"
            debug="yes" debuglevel="lines,source,vars" optimize="yes">
           <src path="${evil.ra.src.dir}" />

--- a/testTools_JMSTestDriver/build.xml
+++ b/testTools_JMSTestDriver/build.xml
@@ -57,7 +57,7 @@
 
 	<!--Compile the project-->
 	<target name="compile" depends="init">
-		<javac  source="1.6" target="1.6" srcdir="${src}" destdir="${build}" debug="Yes" deprecation="Yes">
+		<javac  source="1.8" target="1.8" srcdir="${src}" destdir="${build}" debug="Yes" deprecation="Yes">
 	         <classpath refid="compile.classpath" />
 		</javac>
 		<copy todir="${build}" preservelastmodified="yes">
@@ -66,7 +66,7 @@
 	</target>
 
 	<target name="compile-utils" depends="init">
-        <javac  source="1.6" target="1.6" srcdir="${src.utils}" destdir="${build}" debug="Yes" deprecation="Yes">
+        <javac  source="1.8" target="1.8" srcdir="${src.utils}" destdir="${build}" debug="Yes" deprecation="Yes">
             <classpath refid="compile.classpath" />
         </javac>
         <copy todir="${build}" preservelastmodified="yes">

--- a/testTools_MQ_MQTTClient/build.xml
+++ b/testTools_MQ_MQTTClient/build.xml
@@ -43,7 +43,7 @@
 	</target>
 
 	<target name="compile" depends="init">
-		<javac  source="1.6" target="1.6" srcdir="${src}" destdir="${build}" debug="Yes" deprecation="Yes">
+		<javac  source="1.8" target="1.8" srcdir="${src}" destdir="${build}" debug="Yes" deprecation="Yes">
 			</javac>
 		<copy todir="${build}" preservelastmodified="yes">
 			<fileset dir="${src}" excludes="**/*.java" />

--- a/testTools_MqttTest/build.xml
+++ b/testTools_MqttTest/build.xml
@@ -50,7 +50,7 @@
 	</target>
 
 	<target name="compile" depends="init">
-		<javac  source="1.6" target="1.6" srcdir="${src}" destdir="${build}" debug="Yes" deprecation="Yes">
+		<javac  source="1.8" target="1.8" srcdir="${src}" destdir="${build}" debug="Yes" deprecation="Yes">
 			<classpath refid="compile.classpath" />
 		</javac>		
 		<copy todir="${build}" preservelastmodified="yes">


### PR DESCRIPTION
Updates that:
   Update to compiling to java bytecode for Java 1.8 and above (as on some newer Java SDKs that is the earliest that can be targeted).
   Update which packages are build pre-reqs for some of the non-default components so they can be built on Fedora 36.