### PR TITLE
[patch] Mention REST lists of clients only include disconnected clients by default

### DIFF
--- a/Documentation/doc_infocenter/com.ibm.ism.doc/Monitoring/admin00027.dita
+++ b/Documentation/doc_infocenter/com.ibm.ism.doc/Monitoring/admin00027.dita
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--Arbortext, Inc., 1988-2011, v.4002--><!DOCTYPE task PUBLIC "-//OASIS//DTD DITA Task//EN" "task.dtd">
 <?Pub Sty _display FontColor="red"?><?Pub Inc?><task id="admin00027" xml:lang="en-us">
-<title>Viewing disconnected MQTT client-related statistics by using <ph conref="../TextEntities.dita#TextEntities/RESTMonAPIs" /></title>
-<shortdesc>System administrators can view disconnected MQTT client-related statistics by using a <ph conref="../TextEntities.dita#TextEntities/RESTMonAPI" />. </shortdesc>
+<title>Viewing MQTT client-related statistics by using <ph conref="../TextEntities.dita#TextEntities/RESTMonAPIs" /></title>
+<shortdesc>System administrators can view MQTT client-related statistics by using a <ph conref="../TextEntities.dita#TextEntities/RESTMonAPI" />. </shortdesc>
 <taskbody>
-<context><p>System administrators can view disconnected MQTT client-related statistics by using a <ph conref="../TextEntities.dita#TextEntities/RESTMonAPI" />, or by using the <ph conref="../TextEntities.dita#TextEntities/ISMgui" />. For more information about using the <ph conref="../TextEntities.dita#TextEntities/ISMgui" /> to view disconnected MQTT client-related
+<context><p>System administrators can view (dis)connected MQTT client-related statistics by using a <ph conref="../TextEntities.dita#TextEntities/RESTMonAPI" />, or by using the <ph conref="../TextEntities.dita#TextEntities/ISMgui" />. For more information about using the <ph conref="../TextEntities.dita#TextEntities/ISMgui" /> to view disconnected MQTT client-related
     statistics, see <xref format="dita" href="admin00026.dita" scope="local" type="task">Viewing
      MQTT client-related statistics by using the GUI</xref>.</p><?Pub Caret 176?></context>
 <steps>
@@ -20,102 +20,107 @@
     <cmd>Provide query parameters requesting the statistics that you want returned in the JSON
      payload. The following example uses cURL to create MQTT client-related statistics:</cmd>
     <info>
-     <codeblock>curl -X GET http://127.0.0.1:9089/ima/v1/monitor/MQTTClient?ClientID=<varname>ClientID</varname>%26StatType=<varname>StatType</varname>%26﻿ConnectionState=<varname>﻿&amp;ConnectionState</varname>%26ResultCount=<varname>ResultCount</varname></codeblock>
-     <p>Where:</p>
-     <ul>
-      <li>
-       <dl>
-        <dlentry>
-         <dt>ClientID</dt>
-         <dd>Optional.</dd>
-         <dd>
-          <p>Specifies the name of the MQTT Client. </p>
-          <p>Asterisk (*) matches 0 or more characters. To use an asterisk (*), you must specify
-           ClientID in the query.</p>
-          <p>The default value is <parmname>*</parmname>.</p>
-         </dd>
-        </dlentry>
-       </dl>
-      </li>
-      <li>
-       <dl>
-        <dlentry>
-         <dt>ResultCount</dt>
-         <dd>Optional.</dd>
-         <dd>
-          <p>Specifies the number of results to display.</p>
-          <p>Options available for selection are 10, 25, 50, and 100.</p>
-          <p>The default is <parmname>25</parmname>.</p>
-         </dd>
-        </dlentry>
-       </dl>
-      </li>
-<li>
-<dl>
-<dlentry>
-<dt>﻿&amp;ConnectionState</dt>
-<dd>Optional.</dd>
-<dd>
-<p>Lists connected clients, or both connected and disconnected clients.</p>
-<p>This value can be one of the following values:<ul>
-<li>
-<dl>
-<dlentry>
-<dt> Connected</dt>
-<dd>Lists clients that are connected to <ph conref="../TextEntities.dita#TextEntities/ISM"/>. </dd>
-</dlentry>
-</dl>
-</li>
-<li>
-<dl>
-<dlentry>
-<dt> All</dt>
-<dd>Lists all clients, whether they are disconnected, or connected to <ph
-conref="../TextEntities.dita#TextEntities/ISM"/>. </dd>
-</dlentry>
-</dl>
-</li>
-</ul></p>
-</dd>
-</dlentry>
-</dl>
-</li>
-      <li>
-       <dl>
-        <dlentry>
-         <dt>StatType</dt>
-         <dd>Optional.</dd>
-         <dd>
-          <p>Specifies the type of data to order the results by.</p>
-          <p>This value can be the following values:<ul>
-<li>
-<dl>
-<dlentry>
-<dt> LastConnectedTimeOldest</dt>
-<dd>The most recent date that the specified client ID connected to <ph
-conref="../TextEntities.dita#TextEntities/ISM"/>. </dd>
-</dlentry>
-</dl>
-</li>
-<li>
-<dl>
-<dlentry>
-<dt> AllUnsorted</dt>
-<dd>Lists all MQTT client IDs that are connected to <ph
-conref="../TextEntities.dita#TextEntities/ISM"/>. </dd>
-<dd>Any value that is specified for <parmname>ResultCount</parmname> is ignored, so setting
-<parmname>StatType</parmname>  to <userinput>AllUnsorted</userinput> can result in a large number of
-responses being generated.</dd>
-</dlentry>
-</dl>
-</li>
-</ul></p>
-          <p>The default value is <parmname>LastConnectedTimeOldest</parmname>.</p>
-         </dd>
-        </dlentry>
-       </dl>
-      </li>
-     </ul>
+      <codeblock>curl -X GET http://127.0.0.1:9089/ima/v1/monitor/MQTTClient?ClientID=<varname>ClientID</varname>%26StatType=<varname>StatType</varname>%26﻿ConnectionState=<varname>﻿&amp;ConnectionState</varname>%26ResultCount=<varname>ResultCount</varname></codeblock>
+      <p>Where:</p>
+      <ul>
+        <li>
+          <dl>
+            <dlentry>
+              <dt>ClientID</dt>
+              <dd>Optional.
+                <p>Specifies the name of the MQTT Client. </p>
+                <p>Asterisk (*) matches 0 or more characters. To use an asterisk (*), you must specify
+                  ClientID in the query.</p>
+                <p>The default value is <parmname>*</parmname>.</p>
+              </dd>
+            </dlentry>
+          </dl>
+        </li>
+        <li>
+          <dl>
+            <dlentry>
+              <dt>ResultCount</dt>
+              <dd>Optional.
+                <p>Specifies the number of results to display. (Ignored if <parmname>StatType</parmname> is set to <userinput>AllUnsorted</userinput>)</p>
+                <p>Options available for selection are 10, 25, 50, and 100.</p>
+                <p>The default is <parmname>25</parmname>.</p>
+              </dd>
+            </dlentry>
+          </dl>
+        </li>
+        <li>
+          <dl>
+            <dlentry>
+              <dt>ConnectionState</dt>
+              <dd>Optional.
+                <p>Lists connected clients, or both connected and disconnected clients.</p>
+                <p>This value can be one of the following values:</p>
+                <ul>
+                  <li>
+                    <dl>
+                      <dlentry>
+                        <dt> Disconnected</dt>
+                        <dd>Lists durable clients that are disconnected from <ph conref="../TextEntities.dita#TextEntities/ISM"/>. </dd>
+                      </dlentry>
+                    </dl>
+                  </li>
+                  <li>
+                    <dl>
+                      <dlentry>
+                        <dt> Connected</dt>
+                        <dd>Lists clients that are connected to <ph conref="../TextEntities.dita#TextEntities/ISM"/>. </dd>
+                      </dlentry>
+                    </dl>
+                  </li>
+                  <li>
+                    <dl>
+                      <dlentry>
+                        <dt> All</dt>
+                        <dd>Lists all clients, whether they are disconnected, or connected to <ph conref="../TextEntities.dita#TextEntities/ISM"/>. </dd>
+                      </dlentry>
+                    </dl>
+                  </li>
+                </ul>
+                <p>The default value is <parmname>Disconnected</parmname>.</p>
+              </dd>
+            </dlentry>
+          </dl>
+        </li>
+        <li>
+          <dl>
+            <dlentry>
+              <dt>StatType</dt>
+              <dd>Optional.
+                <p>Specifies the type of data to order the results by.</p>
+                <p>This value can be the following values:</p>
+                <ul>
+                  <li>
+                    <dl>
+                      <dlentry>
+                        <dt> LastConnectedTimeOldest</dt>
+                        <dd>The most recent date that the specified client ID connected to <ph
+                          conref="../TextEntities.dita#TextEntities/ISM"/>. </dd>
+                      </dlentry>
+                    </dl>
+                  </li>
+                  <li>
+                    <dl>
+                      <dlentry>
+                        <dt> AllUnsorted</dt>
+                        <dd><p>Lists all MQTT client IDs that are connected to <ph conref="../TextEntities.dita#TextEntities/ISM"/>. </p>
+                            <p>Any value that is specified for <parmname>ResultCount</parmname> is ignored, so setting
+                            <parmname>StatType</parmname>  to <userinput>AllUnsorted</userinput> can result in a large number of
+                            responses being generated.</p></dd>
+                      </dlentry>
+                    </dl>
+                  </li>
+                </ul>
+                <p>The default value is <parmname>LastConnectedTimeOldest</parmname>.</p>
+              </dd>
+            </dlentry>
+          </dl>
+        </li>
+      </ul>
     </info>
    </step>
 </steps>
@@ -154,9 +159,7 @@ responses being generated.</dd>
 <example>
    <p>The following example uses cURL to show how a GET method is used to create statistics about a
     disconnected MQTT Client with a Client ID that is set to DemoClientID:</p>
-   <codeblock>curl -X GET http://127.0.0.1:9089/ima/v1/monitor/MQTTClient?ClientID=DemoClientID
- 
- </codeblock>
+   <codeblock>curl -X GET http://127.0.0.1:9089/ima/v1/monitor/MQTTClient?ClientID=DemoClientID</codeblock>
    <p>The following example shows a successful example response to the GET method that was used to
     create statistics about a disconnected MQTT Client with a Client ID that is set to
     DemoClientID:</p>


### PR DESCRIPTION
Doc updates based on feedback on slack:
https://eclipse-iot-wg.slack.com/archives/C0206GDEKFC/p1661352173086139