### PR TITLE
Updates from moving to a more recent compiler

### DIFF
--- a/server_build/build.sh
+++ b/server_build/build.sh
@@ -123,7 +123,9 @@ if [ -n "$BUILD_LOG" ]; then
         # until we can clean up compiler warnings (with gcc9) we cannot tee stderr without breaking the travis build (exceed 4MB log size)
         ${MAKCMD} ${target} >> $BUILD_LOG 2>&1
     else
-        ${MAKCMD} ${target} >> $BUILD_LOG 2> >(tee -a $BUILD_LOG >&2 | tail -n 200)
+        echo "JON: Yep in this leg"
+        ${MAKCMD} ${target} >> $BUILD_LOG 2>&1
+        #${MAKCMD} ${target} >> $BUILD_LOG 2> >(tee -a $BUILD_LOG >&2 | tail -n 200)
     fi
 else
     ${MAKCMD} ${target}

--- a/server_build/build.sh
+++ b/server_build/build.sh
@@ -123,7 +123,7 @@ if [ -n "$BUILD_LOG" ]; then
         # until we can clean up compiler warnings (with gcc9) we cannot tee stderr without breaking the travis build (exceed 4MB log size)
         ${MAKCMD} ${target} >> $BUILD_LOG 2>&1
     else
-        ${MAKCMD} ${target} >> $BUILD_LOG 2> >(tee -a $BUILD_LOG >&2)
+        ${MAKCMD} ${target} >> $BUILD_LOG 2> >(tee -a $BUILD_LOG >&2 | tail -n 200)
     fi
 else
     ${MAKCMD} ${target}

--- a/server_build/build.sh
+++ b/server_build/build.sh
@@ -119,11 +119,14 @@ if [ -n "$BUILD_LOG" ]; then
     #exec 3>&1 
     #exec > >(tee -a ${BUILD_LOG} >/dev/null) 2> >(tee -a ${BUILD_LOG} >&3)
     # ${MAKCMD} ${target} >> "$BUILD_LOG"
-    if [ "$ASAN_BUILD" == "yes" ] ; then
+
+    if [[ "$START_DIR" == *"spidercast"* ]] ; then
+        # spidercast uses lots of deprecated C++
         # until we can clean up compiler warnings (with gcc9) we cannot tee stderr without breaking the travis build (exceed 4MB log size)
+        echo "Not printing spidercast errors due to depracted C++ warnings. See build_log for details: ${BUILD_LOG}"
         ${MAKCMD} ${target} >> $BUILD_LOG 2>&1
     else
-        echo "JON: Yep in this leg"
+        echo "Build log at ${BUILD_LOG} but make stderr also shown here"
         ${MAKCMD} ${target} >> $BUILD_LOG 2> >(tee -a $BUILD_LOG >&2)
         #${MAKCMD} ${target} >> $BUILD_LOG 2>&1
         #${MAKCMD} ${target} >> $BUILD_LOG 2> >(tee -a $BUILD_LOG >&2 | tail -n 200)

--- a/server_build/build.sh
+++ b/server_build/build.sh
@@ -124,7 +124,8 @@ if [ -n "$BUILD_LOG" ]; then
         ${MAKCMD} ${target} >> $BUILD_LOG 2>&1
     else
         echo "JON: Yep in this leg"
-        ${MAKCMD} ${target} >> $BUILD_LOG 2>&1
+        ${MAKCMD} ${target} >> $BUILD_LOG 2> >(tee -a $BUILD_LOG >&2)
+        #${MAKCMD} ${target} >> $BUILD_LOG 2>&1
         #${MAKCMD} ${target} >> $BUILD_LOG 2> >(tee -a $BUILD_LOG >&2 | tail -n 200)
     fi
 else

--- a/server_build/build.sh
+++ b/server_build/build.sh
@@ -123,7 +123,7 @@ if [ -n "$BUILD_LOG" ]; then
     if [[ "$START_DIR" == *"spidercast"* ]] ; then
         # spidercast uses lots of deprecated C++
         # until we can clean up compiler warnings (with gcc9) we cannot tee stderr without breaking the travis build (exceed 4MB log size)
-        echo "Not printing spidercast errors due to depracted C++ warnings. See build_log for details: ${BUILD_LOG}"
+        echo "Not printing spidercast errors due to deprecated C++ warnings. See build_log for details: ${BUILD_LOG}"
         ${MAKCMD} ${target} >> $BUILD_LOG 2>&1
     else
         echo "Build log at ${BUILD_LOG} but make stderr also shown here"

--- a/server_build/build_pkg.sh
+++ b/server_build/build_pkg.sh
@@ -840,7 +840,9 @@ function bld_imaproxy_rpm {
         if [ ! -z $CURL_HOME -a -e $CURL_HOME/lib ] ; then
             cp --no-preserve=ownership $CURL_HOME/lib/libcurl.so.4 ${PROXY_BASE_DIR}/${IMA_PROXY_INSTALL_PATH}/lib64/.
         fi
+    fi
 
+    if [ "$SHIP_MONGO" != "no" ] ; then
         if [ -n "$MONGOC_HOME" -a -e $MONGOC_HOME/lib64 ] ; then
           cp --no-preserve=ownership $MONGOC_HOME/lib64/libbson-1.0.so.0 ${PROXY_BASE_DIR}/${IMA_PROXY_INSTALL_PATH}/lib64/.
           cp --no-preserve=ownership $MONGOC_HOME/lib64/libmongoc-1.0.so.0 ${PROXY_BASE_DIR}/${IMA_PROXY_INSTALL_PATH}/lib64/.

--- a/server_proxy/src/javaconfig.c
+++ b/server_proxy/src/javaconfig.c
@@ -2239,6 +2239,10 @@ static int findjvm(char * jvmdll, int len, const char * jvmname) {
         snprintf(jvmdll, len, "%s/lib/amd64/classic/%s", java_home, JVMDLLNAME);
         if (!access(jvmdll, CANREAD))
             return 0;
+        //Path in IBM Java 11:
+        snprintf(jvmdll, len, "%s/lib/server/%s", java_home, JVMDLLNAME);
+        if (!access(jvmdll, CANREAD))
+            return 0;
         jvmname = "lib/amd64/server";
     }
     snprintf(jvmdll, len, "%s/jre/%s/%s", java_home, jvmname, JVMDLLNAME);

--- a/server_tmsmsgtool/nut_translations/nut_msgtoolwrapper.py
+++ b/server_tmsmsgtool/nut_translations/nut_msgtoolwrapper.py
@@ -57,13 +57,13 @@ def runMsgTool(logger, langliststr, replace_filename_vars, input, outputbasedir,
         try:
             output = subprocess.run(msgtoolarglist, 
                                     cwd=msgtoolbindir,
-                                    capture_output=True)
+                                    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         except Exception as e:
             logger.error("Failed to run %s - error %s" %
-                             (shlex.join(msgtoolarglist), e))
+                             (' '.join(shlex.quote(x) for x in msgtoolarglist), e))
             raise e
 
-        logger.info("Output from running: "+shlex.join(msgtoolarglist)+" is: "+output.stdout.decode('utf-8')+" and stderr: "+output.stderr.decode('utf-8'))
+        logger.info("Output from running: "+' '.join(shlex.quote(x) for x in msgtoolarglist)+" is: "+output.stdout.decode('utf-8')+" and stderr: "+output.stderr.decode('utf-8'))
 
         #Copy msgtoolbindir/ism.xml to outputbasedir
         outputbasedir_varsreplaced = nut_utils.parseFileNameForLangVars(outputbasedir, lang)

--- a/server_tmsmsgtool/nut_translations/nut_xsltprocwrapper.py
+++ b/server_tmsmsgtool/nut_translations/nut_xsltprocwrapper.py
@@ -54,10 +54,11 @@ def runXSLTProc(logger, langliststr, replace_filename_vars, input, output,
 
         try:
             procoutput = subprocess.run(xsltprocarglist, 
-                                    capture_output=True)
+                                        stdout=subprocess.PIPE,
+                                        stderr=subprocess.PIPE)
         except Exception as e:
             logger.error("Failed to run %s - error %s" %
-                             (shlex.join(xsltprocarglist), e))
+                             (' '.join(shlex.quote(x) for x in xsltprocarglist), e))
             raise e
 
-        logger.info("Output from running: "+shlex.join(xsltprocarglist)+" is: "+procoutput.stdout.decode('utf-8')+" and stderr: "+procoutput.stderr.decode('utf-8'))
+        logger.info("Output from running: "+' '.join(shlex.quote(x) for x in xsltprocarglist)+" is: "+procoutput.stdout.decode('utf-8')+" and stderr: "+procoutput.stderr.decode('utf-8'))


### PR DESCRIPTION
gcc now reports that the spidercast component uses lots of deprecated C++. Temporarily we have to suppress these warnings from the screen to stop builds failing with overly long logs.

I've also made some updates so the translation works with older version of python (3.6) and so we look in more places for a JVM is we need one.