### PR TITLE
Add more customization options to the operator to support 3rd party builds of amlen

### DIFF
--- a/operator/roles/amlen/tasks/create_pair.yml
+++ b/operator/roles/amlen/tasks/create_pair.yml
@@ -85,7 +85,25 @@
     definition: "{{ lookup('template', item ) | from_yaml }}"
   loop:
   - ./templates/statefulset.j2
+
+- name: Set the loadbalancer to {{ _amlen_state }}
+  k8s:
+    state: "{{ _amlen_state }}"
+    merge_type:
+    - strategic-merge
+    - merge
+    definition: "{{ lookup('template', item ) | from_yaml }}"
+  loop:
   - ./templates/loadbalancer.j2
+
+- name: Set the networkpolicy to {{ _amlen_state }}
+  k8s:
+    state: "{{ _amlen_state }}"
+    merge_type:
+    - strategic-merge
+    - merge
+    definition: "{{ lookup('template', item ) | from_yaml }}"
+  loop:
   - ./templates/networkpolicy.j2
 
 - name: Create Device Certificates

--- a/operator/roles/amlen/templates/statefulset.j2
+++ b/operator/roles/amlen/templates/statefulset.j2
@@ -48,7 +48,7 @@ spec:
           exec:
             command:
             - python3
-            - /usr/share/amlen-server/bin/readiness.py
+            - "{{_amlen_bin_directory | default('/usr/share/amlen-server/bin/')}}readiness.py"
           initialDelaySeconds: 10
           timeoutSeconds: 5
           periodSeconds: 20
@@ -73,7 +73,7 @@ spec:
             memory: "{{ _amlen_memory_limit }}"
         volumeMounts:
         - name: data
-          mountPath: /var/lib/amlen-server
+          mountPath: "{{_amlen_directory | default('/var/lib/amlen-server/')}}"
         - name: adminpassword
           mountPath: /secrets/adminpassword
         - name: device-certs
@@ -82,7 +82,7 @@ spec:
           mountPath: /secrets/ha_certs
         env:
         - name: CONTAINER_PASSWORD_CHECK
-         value: "true"
+          value: "true"
 {% if _amlen_image_pull_secret is defined %}
       imagePullSecrets:
       - name: "{{_amlen_image_pull_secret}}"

--- a/operator/roles/amlen/templates/statefulset.j2
+++ b/operator/roles/amlen/templates/statefulset.j2
@@ -82,7 +82,11 @@ spec:
           mountPath: /secrets/ha_certs
         env:
         - name: CONTAINER_PASSWORD_CHECK
-          value: "true"
+         value: "true"
+{% if defined _amlen_image_pull_secret %}
+      imagePullSecrets:
+      - name: "{{_amlen_image_pull_secret}}"
+{% endif %}
       volumes:
         - name: adminpassword
           secret: 

--- a/operator/roles/amlen/templates/statefulset.j2
+++ b/operator/roles/amlen/templates/statefulset.j2
@@ -83,7 +83,7 @@ spec:
         env:
         - name: CONTAINER_PASSWORD_CHECK
          value: "true"
-{% if defined _amlen_image_pull_secret %}
+{% if _amlen_image_pull_secret is defined %}
       imagePullSecrets:
       - name: "{{_amlen_image_pull_secret}}"
 {% endif %}


### PR DESCRIPTION
- Added optional imagePullSecret to allow operator to pull from private repositories
- Added options to override directories used in the amlen pod
- Split out the apply steps in operator for loadbalancer, statefulset and networkpolicy to make it easier to work out which has failed 