### PR TITLE
Add topologySpreadConstraint to allow multi AZ zones

### DIFF
--- a/operator/roles/amlen/defaults/main.yml
+++ b/operator/roles/amlen/defaults/main.yml
@@ -16,7 +16,7 @@ _amlen_monitor_image: quay.io/amlen/amlen-monitor
 _amlen_monitor_image_tag: IMG_TAG
 _amlen_storage_class: default
 _amlen_persistence: "true"
-_amlen_topologySpreadConstraints_whenUnsatisfiable: scheduleAnyway
+_amlen_topology_spread_constraints_when_unsatisfiable: ScheduleAnyway
 
 amlen_messaging_ports:
   securemessaging: 8883

--- a/operator/roles/amlen/defaults/main.yml
+++ b/operator/roles/amlen/defaults/main.yml
@@ -16,6 +16,7 @@ _amlen_monitor_image: quay.io/amlen/amlen-monitor
 _amlen_monitor_image_tag: IMG_TAG
 _amlen_storage_class: default
 _amlen_persistence: "true"
+_amlen_topologySpreadConstraints_whenUnsatisfiable: scheduleAnyway
 
 amlen_messaging_ports:
   securemessaging: 8883

--- a/operator/roles/amlen/tasks/create_pair.yml
+++ b/operator/roles/amlen/tasks/create_pair.yml
@@ -82,7 +82,7 @@
 
 - name: ha cert secret
   set_fact:
-    ha_certs_secret: "{{ (ha is defined and ha.cert_issuer is defined && ha.cert_issuer.secret is defined and ha.cert_issuer.secret) or '{{pair_name}}-cert-ha)' }}"
+    ha_certs_secret: "{{ (ha is defined and ha.cert_issuer is defined and ha.cert_issuer.secret is defined and ha.cert_issuer.secret) or '{{pair_name}}-cert-ha)' }}"
 
 - name: Set the statefulset to {{ _amlen_state }}
   k8s:

--- a/operator/roles/amlen/tasks/create_pair.yml
+++ b/operator/roles/amlen/tasks/create_pair.yml
@@ -78,11 +78,11 @@
 
 - name: device cert secret
   set_fact:
-    device_certs_secret: "{{ (device_cert_issuer and device_cert_issuer.secret is defined and device_cert_issuer.secret) or '{{pair_name}}-cert-devices)' }}"
+    device_certs_secret: "{{ (device_cert_issuer and device_cert_issuer.secret is defined and device_cert_issuer.secret) or '{{pair_name}}-cert-devices' }}"
 
 - name: ha cert secret
   set_fact:
-    ha_certs_secret: "{{ (ha is defined and ha.cert_issuer is defined and ha.cert_issuer.secret is defined and ha.cert_issuer.secret) or '{{pair_name}}-cert-ha)' }}"
+    ha_certs_secret: "{{ (ha is defined and ha.cert_issuer is defined and ha.cert_issuer.secret is defined and ha.cert_issuer.secret) or '{{pair_name}}-cert-ha' }}"
 
 - name: Set the statefulset to {{ _amlen_state }}
   k8s:

--- a/operator/roles/amlen/tasks/create_pair.yml
+++ b/operator/roles/amlen/tasks/create_pair.yml
@@ -76,9 +76,13 @@
     device_certs_required: false
   when: device_certs_required is not defined
 
-- name: device cert name
+- name: device cert secret
   set_fact:
     device_certs_secret: "{{ (device_cert_issuer and device_cert_issuer.secret is defined and device_cert_issuer.secret) or '{{pair_name}}-cert-devices)' }}"
+
+- name: ha cert secret
+  set_fact:
+    ha_certs_secret: "{{ (ha is defined and ha.cert_issuer is defined && ha.cert_issuer.secret is defined and ha.cert_issuer.secret) or '{{pair_name}}-cert-ha)' }}"
 
 - name: Set the statefulset to {{ _amlen_state }}
   k8s:
@@ -141,7 +145,7 @@
     renewBefore: "{{ ha.cert_issuer.renew_before  | default() }}"
     waitForCert: yes
   loop:
-  - name: "{{pair_name}}-cert-ha"
+  - name: "{{ha_certs_secret}}"
     serviceName: "amlen"
     usages: [ "client auth", "server auth" ]
     algorithm: "ECDSA"

--- a/operator/roles/amlen/tasks/create_pair.yml
+++ b/operator/roles/amlen/tasks/create_pair.yml
@@ -78,7 +78,7 @@
 
 - name: device cert name
   set_fact:
-    device_certs_secret: "{{ (device_cert_issuer and device_cert_issuer.secret is defined and device_cert_issuer.secret) or '{{pair-name}}-cert-devices)' }} "
+    device_certs_secret: "{{ (device_cert_issuer and device_cert_issuer.secret is defined and device_cert_issuer.secret) or '{{pair_name}}-cert-devices)' }}"
 
 - name: Set the statefulset to {{ _amlen_state }}
   k8s:

--- a/operator/roles/amlen/templates/statefulset.j2
+++ b/operator/roles/amlen/templates/statefulset.j2
@@ -37,7 +37,7 @@ spec:
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: "{{_amlen_topologySpreadConstraints_whenUnsatisfiable}}"
+        whenUnsatisfiable: "{{_amlen_topology_spread_constraints_when_unsatisfiable}}"
         labelSelector: 
           matchLabels:
             app: "{{ pair_name }}"

--- a/operator/roles/amlen/templates/statefulset.j2
+++ b/operator/roles/amlen/templates/statefulset.j2
@@ -37,7 +37,7 @@ spec:
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: "{{ _amlen_topologySpreadConstraints_whenUnsatisfiable || default (ScheduleAnyway) }}"
+        whenUnsatisfiable: "{{ _amlen_topologySpreadConstraints_whenUnsatisfiable | default (ScheduleAnyway) }}"
         labelSelector: 
           matchLabels:
             app: "{{ pair_name }}"

--- a/operator/roles/amlen/templates/statefulset.j2
+++ b/operator/roles/amlen/templates/statefulset.j2
@@ -37,7 +37,7 @@ spec:
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: "{{_amlen_topologySpreadConstraints_whenUnsatisfiable | default('ScheduleAnyway') }}"
+        whenUnsatisfiable: "{{_amlen_topologySpreadConstraints_whenUnsatisfiable}}"
         labelSelector: 
           matchLabels:
             app: "{{ pair_name }}"

--- a/operator/roles/amlen/templates/statefulset.j2
+++ b/operator/roles/amlen/templates/statefulset.j2
@@ -104,7 +104,7 @@ spec:
             optional: {{ not device_certs_required }}
         - name: ha-certs
           secret:
-            secretName: "{{ha.cert_issuer.name | default( '{{pair_name}}-cert-ha') }}"
+            secretName: "{{ha_certs_secret}}"
             optional: {{ standalone }}
  
 {% if _amlen_persistence == "false" %}

--- a/operator/roles/amlen/templates/statefulset.j2
+++ b/operator/roles/amlen/templates/statefulset.j2
@@ -37,7 +37,7 @@ spec:
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
+        whenUnsatisfiable: "{{ _amlen_topologySpreadConstraints_whenUnsatisfiable || default (ScheduleAnyway) }}"
         labelSelector: 
           matchLabels:
             app: "{{ pair_name }}"

--- a/operator/roles/amlen/templates/statefulset.j2
+++ b/operator/roles/amlen/templates/statefulset.j2
@@ -34,6 +34,13 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: amlen
     spec:
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector: 
+          matchLabels:
+            app: "{{ pair_name }}"
       containers:
       - name: monitor
         image: "{{ _amlen_monitor_image }}:{{ _amlen_monitor_image_tag}}"

--- a/operator/roles/amlen/templates/statefulset.j2
+++ b/operator/roles/amlen/templates/statefulset.j2
@@ -104,7 +104,7 @@ spec:
             optional: {{ not device_certs_required }}
         - name: ha-certs
           secret:
-            secretName: "ha.cert_issuer.name | default( '{{pair_name}}-cert-ha') }}"
+            secretName: "{{ha.cert_issuer.name | default( '{{pair_name}}-cert-ha') }}"
             optional: {{ standalone }}
  
 {% if _amlen_persistence == "false" %}

--- a/operator/roles/amlen/templates/statefulset.j2
+++ b/operator/roles/amlen/templates/statefulset.j2
@@ -37,7 +37,7 @@ spec:
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: "{{ _amlen_topologySpreadConstraints_whenUnsatisfiable | default (ScheduleAnyway) }}"
+        whenUnsatisfiable: "{{ _amlen_topologySpreadConstraints_whenUnsatisfiable | default ('ScheduleAnyway') }}"
         labelSelector: 
           matchLabels:
             app: "{{ pair_name }}"

--- a/operator/roles/amlen/templates/statefulset.j2
+++ b/operator/roles/amlen/templates/statefulset.j2
@@ -37,7 +37,7 @@ spec:
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: "{{ _amlen_topologySpreadConstraints_whenUnsatisfiable | default ('ScheduleAnyway') }}"
+        whenUnsatisfiable: "{{_amlen_topologySpreadConstraints_whenUnsatisfiable | default('ScheduleAnyway') }}"
         labelSelector: 
           matchLabels:
             app: "{{ pair_name }}"

--- a/operator/roles/amlen/templates/statefulset.j2
+++ b/operator/roles/amlen/templates/statefulset.j2
@@ -37,7 +37,7 @@ spec:
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: DoNotSchedule
+        whenUnsatisfiable: ScheduleAnyway
         labelSelector: 
           matchLabels:
             app: "{{ pair_name }}"


### PR DESCRIPTION
Adds _amlen_topology_spread_contraints_when_unsatisfiable to allow the crd to specify that multi zone must be enforced
Also fixes up some certificate issues