### PR TITLE
Downloads Page: Clarify which releases are actually released

### DIFF
--- a/websites/download/index.html
+++ b/websites/download/index.html
@@ -10,7 +10,7 @@
   <p><a href="https://www.eclipse.org/amlen/">Amlen Home</a></p>
   <p>Releases</p>
   <ul>
-  <li><a href="#1.1">1.1</a></li>
+  <li><a href="#1.1">1.1 (alpha)</a></li>
   <li><a href="#1.0">1.0</a></li>
   </ul>
   <p>Other:</p>
@@ -23,6 +23,7 @@
   <div id="maincontent">
      <h1>Eclipse Amlen&trade; Downloads</h1>
      
+     <h2> Pre-Releases and Betas</h2>
      <h3>1.1.0</h3>
 
      <a name="1.1"/>
@@ -35,7 +36,7 @@
 <a href="https://www.eclipse.org/downloads/download.php?file=/amlen/releases/1.1.0-alpha/centos7/EclipseAmlenBridge-centos7-1.1dev-20220809-1356_eclipsecentos7.tar.gz">Amlen Bridge 1.1.0-alpha</a>, 
      </ul>
      
-     <h3>Older Releases</h3>
+     <h2>Current Stable Releases</h2>
      <h3>1.0.0.1</h3>
 
      <a name="1.0"></a>
@@ -57,10 +58,10 @@ NB: The WebUI requires openldap-servers which is available in the RHEL <a href="
 <a href="https://download.eclipse.org/amlen/releases/1.0.0.1/fedora/contrib/">Others</a></li>
      </ul>
      
-     <h3>Older Releases</h3>
+     <h2>Older Releases</h2>
      <p>Older Releases can be seen <a href="https://download.eclipse.org/amlen/releases">here</a> (or in the <a href="https://archive.eclipse.org/amlen/">archives</a>)</p>
      
-     <h3>Snapshot Builds</h3>
+     <h2>Snapshot Builds</h2>
      <p><a href="https://download.eclipse.org/amlen/snapshots/">Snapshot builds</a> of dev branches are also available. Some older snapshot may be available in the <a href="https://archive.eclipse.org/amlen/">archives</a></p>
   </div>
 </div>


### PR DESCRIPTION
I have had a slack comment and an email by people confused about whether 1.1 is release so updated the downloads page to clarify a bit.
