### PR TITLE
update csv for manual installation

### DIFF
--- a/operator/config/manifests/bases/eclipse-amlen-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/eclipse-amlen-operator.clusterserviceversion.yaml
@@ -2,31 +2,279 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    alm-examples: '[]'
-    capabilities: Basic Install
-  name: eclipse-amlen-operator.v0.0.0
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "eclipse.org/v1",
+          "kind": "Amlen",
+          "metadata": {
+            "name": "amlen-sample"
+          },
+          "spec": {
+            "_amlen_image_tag": "latest",
+            "_amlen_monitor_image_tag": "latest",
+            "_amlen_name": "amlen-sample",
+            "_amlen_namespace": "osdk-test",
+            "_amlen_persistence": "false",
+            "config": "amlen-config",
+            "device_cert_issuer": {
+              "mode": "automatic",
+              "name": "amlen-selfsigned-issuer"
+            },
+            "ha": {
+              "cert_issuer": {
+                "name": "amlen-selfsigned-issuer"
+              },
+              "enabled": true
+            },
+            "size": 2
+          }
+        }
+      ]
+    capabilities: Seamless Upgrades
+    categories: Streaming & Messaging
+    containerImage: quay.io/amlen/operator:v1.0.1a
+    createdAt: "2022-11-24T15:31:00Z"
+    description: An operator to run the Eclipse Amlen MQTT Broker
+    operators.operatorframework.io/builder: operator-sdk-v1.25.2
+    operators.operatorframework.io/project_layout: ansible.sdk.operatorframework.io/v1
+    repository: https://github.com/eclipse/amlen
+  name: eclipse-amlen-operator.v1.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
-  customresourcedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - kind: Amlen
+      name: amlens.eclipse.org
+      version: v1
   description: Operator for the eclipse Amlen MQTT Broker\n\n### Supported Feature\n\n
-    Currently supports:\n* Install - simple install process\n* Upgrade - non-disruptive upgrade\n*High
-    Availability - can be enabled/disabled via the CRD\n\n### Documentation\nThe main
-    Amlen website has links to product documentation, forum, blog and the slack channel\nhttp://www.eclipse.org/amlen\n\n###
-    Getting help\nThe quickest way to get help is to use the slack channel but the
-    forum is monitored as well\n\nIssues can also be added to the github repository
-    https://github.com/eclipse/amlen\n\n### License\nEclipse Amlen Operator is licensed
-    under the [Eclipse Public License - v 2.0](https://www.eclipse.org/legal/epl-2.0/)
+    Currently supports:\n* Install - simple install process\n* Upgrade - non-disruptive
+    upgrade\n*High Availability - can be enabled/disabled via the CRD\n\n### Documentation\nThe
+    main Amlen website has links to product documentation, forum, blog and the slack
+    channel\nhttp://www.eclipse.org/amlen\n\n### Getting help\nThe quickest way to
+    get help is to use the slack channel but the forum is monitored as well\n\nIssues
+    can also be added to the github repository https://github.com/eclipse/amlen\n\n###
+    License\nEclipse Amlen Operator is licensed under the [Eclipse Public License
+    - v 2.0](https://www.eclipse.org/legal/epl-2.0/)
   displayName: eclipse-amlen-operator
   icon:
-  - base64data: ""
-    mediatype: ""
+  - base64data: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNTguNTEgMjU4LjUxIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2QxZDFkMTt9LmNscy0ye2ZpbGw6IzhkOGQ4Zjt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPkFzc2V0IDQ8L3RpdGxlPjxnIGlkPSJMYXllcl8yIiBkYXRhLW5hbWU9IkxheWVyIDIiPjxnIGlkPSJMYXllcl8xLTIiIGRhdGEtbmFtZT0iTGF5ZXIgMSI+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMTI5LjI1LDIwQTEwOS4xLDEwOS4xLDAsMCwxLDIwNi40LDIwNi40LDEwOS4xLDEwOS4xLDAsMSwxLDUyLjExLDUyLjExLDEwOC40NSwxMDguNDUsMCwwLDEsMTI5LjI1LDIwbTAtMjBoMEM1OC4xNiwwLDAsNTguMTYsMCwxMjkuMjVIMGMwLDcxLjA5LDU4LjE2LDEyOS4yNiwxMjkuMjUsMTI5LjI2aDBjNzEuMDksMCwxMjkuMjYtNTguMTcsMTI5LjI2LTEyOS4yNmgwQzI1OC41MSw1OC4xNiwyMDAuMzQsMCwxMjkuMjUsMFoiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik0xNzcuNTQsMTAzLjQxSDE0MS42NkwxNTQuOSw2NS43NmMxLjI1LTQuNC0yLjMzLTguNzYtNy4yMS04Ljc2SDEwMi45M2E3LjMyLDcuMzIsMCwwLDAtNy40LDZsLTEwLDY5LjYxYy0uNTksNC4xNywyLjg5LDcuODksNy40LDcuODloMzYuOUwxMTUuNTUsMTk3Yy0xLjEyLDQuNDEsMi40OCw4LjU1LDcuMjQsOC41NWE3LjU4LDcuNTgsMCwwLDAsNi40Ny0zLjQ4TDE4NCwxMTMuODVDMTg2Ljg2LDEwOS4yNCwxODMuMjksMTAzLjQxLDE3Ny41NCwxMDMuNDFaIi8+PC9nPjwvZz48L3N2Zz4=
+    mediatype: image/svg+xml
   install:
     spec:
-      deployments: null
-    strategy: ""
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          - pods
+          - pods/exec
+          - pods/log
+          - services
+          - routes
+          - persistentvolumeclaims
+          - serviceaccounts
+          - configmaps
+          - jobs
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - eclipse.org
+          resources:
+          - amlens
+          - amlens/status
+          - amlens/finalizers
+          - jobs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - cert-manager.io
+          resources:
+          - certificates
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: amlen-controller-manager
+      deployments:
+      - label:
+          control-plane: controller-manager
+        name: amlen-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+              labels:
+                app: amlen-operator
+                control-plane: controller-manager
+            spec:
+              containers:
+              - args:
+                - --secure-listen-address=0.0.0.0:8443
+                - --upstream=http://127.0.0.1:8080/
+                - --logtostderr=true
+                - --v=0
+                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+                name: kube-rbac-proxy
+                ports:
+                - containerPort: 8443
+                  name: https
+                  protocol: TCP
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 5m
+                    memory: 64Mi
+              - args:
+                - --health-probe-bind-address=:6789
+                - --metrics-bind-address=127.0.0.1:8080
+                - --leader-elect
+                - --leader-election-id=amlen
+                env:
+                - name: ANSIBLE_GATHERING
+                  value: explicit
+                image: quay.io/amlen/operator:v1.0.1a
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 6789
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 6789
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 768Mi
+                  requests:
+                    cpu: 10m
+                    memory: 256Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: amlen-controller-manager
+              terminationGracePeriodSeconds: 10
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: amlen-controller-manager
+    strategy: deployment
   installModes:
-  - supported: false
+  - supported: true
     type: OwnNamespace
   - supported: false
     type: SingleNamespace
@@ -40,11 +288,11 @@ spec:
   - broker
   links:
   - name: Eclipse Amlen Operator
-    url: https://eclipse-amlen-operator.domain
+    url: https://eclipse.org/amlen
   maintainers:
   - email: ianboden@uk.ibm.com
     name: Ian Boden
   maturity: stable
   provider:
     name: Ian Boden
-  version: 0.0.0
+  version: 1.0.0


### PR DESCRIPTION
Some of the CSV fields hadn't been updated to match those in the operator hub meaning if you install it manually from the bundle it wouldn't be compatible. Long term we need to ensure they match or see if there is another way to do it so we don't have the operator bundle in quay.io and a second one hidden away in operator hub.