### PR TITLE
Support digests and auto recovery of statefulset

### DIFF
--- a/operator/build/scripts/monitor.py
+++ b/operator/build/scripts/monitor.py
@@ -26,6 +26,9 @@ def get_password():
 
 if __name__ == '__main__':
 
+    if os.environ.get("AMLEN_MONITOR_CODE") == None:
+        return
+
     imaserver = Server("localhost", logger )
     current_password = get_password()
     while True :

--- a/operator/build/scripts/monitor.py
+++ b/operator/build/scripts/monitor.py
@@ -26,7 +26,7 @@ def get_password():
 
 if __name__ == '__main__':
 
-    if os.environ.get("AMLEN_MONITOR_CODE") == None:
+    if os.environ.get("AMLEN_OPERATOR") == None:
         return
 
     imaserver = Server("localhost", logger )

--- a/operator/build/scripts/monitor.py
+++ b/operator/build/scripts/monitor.py
@@ -11,6 +11,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
+import os
 import time
 from server import Server, get_logger
 
@@ -27,7 +28,7 @@ def get_password():
 if __name__ == '__main__':
 
     if os.environ.get("AMLEN_OPERATOR") == None:
-        return
+        exit
 
     imaserver = Server("localhost", logger )
     current_password = get_password()

--- a/operator/build/scripts/readiness.py
+++ b/operator/build/scripts/readiness.py
@@ -21,8 +21,9 @@ def ready(instance):
 
     if p1_ha and p1_state == "PRIMARY":
         logger.info("We are primary so check node count!")
+        startup_mode = instance.get_ha_startup_mode()
         nodes = instance.get_ha_sync_nodes()
-        return bool(nodes > 1)
+        return bool(nodes > 1 or startup_mode.lower() == "standalone")
     if p1_ha and p1_state == "STANDBY":
         logger.info("We are standby!")
         return True

--- a/operator/build/scripts/server.py
+++ b/operator/build/scripts/server.py
@@ -323,10 +323,10 @@ class Server:
         return thing
 
     def get_configuration(self, configuration_type, wait=True):
-        return get_thing(self, f"configuraiton/HighAvailability", wait)
+        return self.get_thing(f"configuraiton/HighAvailability", wait)
 
     def get_status(self, wait=True):
-        return get_thing(self, f"service/status", wait)
+        return self.get_thing(f"service/status", wait)
 
 
     def check_ha_status(self):

--- a/operator/build/scripts/server.py
+++ b/operator/build/scripts/server.py
@@ -238,7 +238,7 @@ class Server:
 
     def get_ha_startup_mode(self):
         jconfig = self.get_configuration("HighAvailability", False)
-        return jstatus["HighAvailability"]["StartupMode"]
+        return jconfig["HighAvailability"]["StartupMode"]
 
     def get_ha_sync_nodes(self):
         jstatus = self.get_status(False)
@@ -323,7 +323,7 @@ class Server:
         return object
 
     def get_configuration(self, configuration_type, wait=True):
-        return self.get_object(f"configuraiton/HighAvailability", wait)
+        return self.get_object(f"configuration/HighAvailability", wait)
 
     def get_status(self, wait=True):
         return self.get_object(f"service/status", wait)

--- a/operator/build/scripts/server.py
+++ b/operator/build/scripts/server.py
@@ -320,7 +320,7 @@ class Server:
 
             time.sleep(5)
 
-        return object
+        return return_object
 
     def get_configuration(self, configuration_type, wait=True):
         return self.get_object(f"configuration/HighAvailability", wait)

--- a/operator/build/scripts/server.py
+++ b/operator/build/scripts/server.py
@@ -292,10 +292,10 @@ class Server:
         return is_ha, state
 
     def get_configuration(self, configuration_type, wait=True):
-        return get_something(self, f"configuraiton/{HighAvailability", wait)
+        return get_thing(self, f"configuraiton/HighAvailability", wait)
 
     def get_status(self, wait=True):
-        return get_something(self, f"service/status", wait)
+        return get_thing(self, f"service/status", wait)
 
     def get_thing(self, thing, wait=True):
 

--- a/operator/build/scripts/server.py
+++ b/operator/build/scripts/server.py
@@ -291,21 +291,21 @@ class Server:
 
         return is_ha, state
 
-    def get_thing(self, thing, wait=True):
+    def get_object(self, object, wait=True):
 
-        thing = None
+        return_object = None
         retries = 10
         for _ in range(0, retries):
-            url = f"https://{self.server_name}:9089/ima/v1/{thing}"
+            url = f"https://{self.server_name}:9089/ima/v1/{object}"
             try:
                 response = requests.get(url=url,
                                         auth=HTTPBasicAuth(self.username, self.password),
                                         timeout=10,
                                         verify=False)
                 if response.status_code == 200:
-                    thing_text = response.content
+                    text = response.content
                     self.logger.debug(response.content)
-                    thing = json.loads(thing_text)
+                    return_object = json.loads(text)
                     break
                 if response.status_code in (400, 401):
                     print (f"Accessing {url} with {self.username} failed")
@@ -320,13 +320,13 @@ class Server:
 
             time.sleep(5)
 
-        return thing
+        return object
 
     def get_configuration(self, configuration_type, wait=True):
-        return self.get_thing(f"configuraiton/HighAvailability", wait)
+        return self.get_object(f"configuraiton/HighAvailability", wait)
 
     def get_status(self, wait=True):
-        return self.get_thing(f"service/status", wait)
+        return self.get_object(f"service/status", wait)
 
 
     def check_ha_status(self):

--- a/operator/build/scripts/server.py
+++ b/operator/build/scripts/server.py
@@ -291,12 +291,6 @@ class Server:
 
         return is_ha, state
 
-    def get_configuration(self, configuration_type, wait=True):
-        return get_thing(self, f"configuraiton/HighAvailability", wait)
-
-    def get_status(self, wait=True):
-        return get_thing(self, f"service/status", wait)
-
     def get_thing(self, thing, wait=True):
 
         thing = None
@@ -327,6 +321,13 @@ class Server:
             time.sleep(5)
 
         return thing
+
+    def get_configuration(self, configuration_type, wait=True):
+        return get_thing(self, f"configuraiton/HighAvailability", wait)
+
+    def get_status(self, wait=True):
+        return get_thing(self, f"service/status", wait)
+
 
     def check_ha_status(self):
         okay = False

--- a/operator/roles/amlen/library/recover.py
+++ b/operator/roles/amlen/library/recover.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2022 Contributors to the Eclipse Foundation
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/operator/roles/amlen/library/recover.py
+++ b/operator/roles/amlen/library/recover.py
@@ -1,0 +1,115 @@
+#!/usr/bin/python
+# Copyright (c) 2022 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+from ansible.module_utils.basic import *
+import socket
+import subprocess
+import time
+import sys
+import os
+import json
+import requests
+import logging
+import traceback
+import re
+import base64
+import yaml
+import argparse
+from subprocess import Popen, PIPE, check_output
+from requests.auth import HTTPBasicAuth
+from ansible.module_utils.server import Server
+
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+
+# Constants
+DEFAULT_HEARTBEAT = 10
+
+def getLogger(name="amlen-recover"):
+    logging.basicConfig(filename='/tmp/amlen-recover.log', level=logging.DEBUG)
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.INFO)
+
+    # Only add the handlers once!
+    if logger.handlers == []:
+        ch = logging.StreamHandler()
+        ch.setLevel(logging.INFO)
+
+        chFormatter = logging.Formatter('%(asctime)-25s %(name)-50s %(threadName)-16s %(levelname)-8s %(message)s')
+        ch.setFormatter(chFormatter)
+
+        logger.addHandler(ch)
+
+    return logger
+
+logger = getLogger()
+
+def startRecovery(server):
+    groupName = server.group_name
+    
+    HA, state = server.get_ha_state(wait=True)
+        
+    if HA and state == "UNSYNC":
+        # A is primary - valid pair
+        server1 = instanceA
+    
+    down = (server.get_status(wait=False) == None)
+
+    if down and HA:
+
+        payload = {"HighAvailability": {"StartupMode" : "StandAlone", "RemoteDiscoveryNIC":"none"}}
+
+        rc, content = server.post_configuration_request(payload)
+        if rc != 200:
+            logger.error("Unexpected response code when modifying HA configuration for %s: %s" % (server.server_name, rc)) 
+            logger.error(content)
+            raise Exception("Unexpected response code when modifying HA configuration for %s: %s" % (server.server_name, rc))
+
+        server,restart())
+
+def stopRecovery(server,remoteServerName):
+    payload = {"HighAvailability": {"StartupMode" : "AutoDetect", "RemoteDiscoveryNIC":remoteServerName}}
+    rc, content = server.post_configuration_request(payload)
+    if rc != 200:
+        logger.error("Unexpected response code when modifying HA configuration for %s: %s" % (server.server_name, rc)) 
+        logger.error(content)
+
+if __name__ == '__main__':
+    fields = {
+        "server": {"required": True, "type": "str" },
+        "remoteServer": {"required": True, "type": "str" },
+        "command": {"required": True, "type": "str"},
+    }
+
+    module = AnsibleModule(argument_spec=fields)
+
+    server = module.params['server']
+    command = module.params['command']
+    remoteServer = module.params['remoteServer']
+    
+    try:
+        imaserver = Server(instance, logger)
+        if commaned.lower() == "start":
+            startRecovery(imaserver)
+        elif command.lower() == "stop":
+            stopRecovery(imaserver,remoteServer)
+        else:
+            logger.critical("Command unknown: %s" % command
+            raise Exception("Command unknown")
+
+    except Exception as e:
+        stackTrace = traceback.format_exc()
+        logger.warn("Failure during recovery: %s" % stackTrace)
+        raise Exception(e)
+
+    module.exit_json(changed=True)

--- a/operator/roles/amlen/tasks/create_pair.yml
+++ b/operator/roles/amlen/tasks/create_pair.yml
@@ -207,13 +207,15 @@
     - fail:
         msg: "statefulset recovery only possible if pod is not ready"
       when:
-        statefulset.resources[0].status.readyReplicas != 1
+      - statefulset.resources[0].status.readyReplicas is defined
+      - statefulset.resources[0].status.readyReplicas == 1
 
     - name: start recovery code
       recover:
         command: "start"
-        server: "{{ _amlen_release }}-{{ _amlen_name }}-{{pair_id}}-0"
+        server: "{{ _amlen_release }}-{{ _amlen_name }}-{{pair_id}}-0.{{_amlen_service_name | default(name)}}.{{_amlen_namespace}}.svc.cluster.local"
         remoteServer: ""
+        password: "{{secret.resources[0].data.adminPassword|b64decode}}"
 
     - name: Verify it worked
       k8s_info:
@@ -236,8 +238,9 @@
     - name: stop recovery code
       recover:
         command: "stop"
-        server: "{{ _amlen_release }}-{{ _amlen_name }}-{{pair_id}}-0"
-        remoteServer: "{{ _amlen_release }}-{{ _amlen_name }}-{{pair_id}}-1" 
+        server: "{{ _amlen_release }}-{{ _amlen_name }}-{{pair_id}}-0.{{_amlen_service_name | default(name)}}.{{_amlen_namespace}}.svc.cluster.local"
+        remoteserver: "{{ _amlen_release }}-{{ _amlen_name }}-{{pair_id}}-1.{{_amlen_service_name | default(name)}}.{{_amlen_namespace}}.svc.cluster.local"
+        password: "{{secret.resources[0].data.adminPassword|b64decode}}"
 
 - name: run post install jobs
   include_tasks: install.yml

--- a/operator/roles/amlen/tasks/create_pair.yml
+++ b/operator/roles/amlen/tasks/create_pair.yml
@@ -192,6 +192,12 @@
         name: "{{ pair_name }}"
         namespace: "{{ _amlen_namespace }}"
       register: statefulset
+      until:
+      - statefulset.resources[0].status.readyReplicas is defined
+      retries: 10
+      delay: 10
+
+
 
     - fail:
         msg: "statefulset contains 2 pods manual recovery needed"

--- a/operator/roles/amlen/tasks/create_pair.yml
+++ b/operator/roles/amlen/tasks/create_pair.yml
@@ -239,7 +239,7 @@
       recover:
         command: "stop"
         server: "{{ _amlen_release }}-{{ _amlen_name }}-{{pair_id}}-0.{{_amlen_service_name | default(name)}}.{{_amlen_namespace}}.svc.cluster.local"
-        remoteserver: "{{ _amlen_release }}-{{ _amlen_name }}-{{pair_id}}-1.{{_amlen_service_name | default(name)}}.{{_amlen_namespace}}.svc.cluster.local"
+        remoteServer: "{{ _amlen_release }}-{{ _amlen_name }}-{{pair_id}}-1.{{_amlen_service_name | default(name)}}.{{_amlen_namespace}}.svc.cluster.local"
         password: "{{secret.resources[0].data.adminPassword|b64decode}}"
 
 - name: run post install jobs

--- a/operator/roles/amlen/tasks/create_pair.yml
+++ b/operator/roles/amlen/tasks/create_pair.yml
@@ -164,22 +164,74 @@
     nodes: "{{ ha.enabled | default(false) | ternary(2,1) }}"
 
 - name: Wait until pods are available
-  k8s_info:
-    kind: Pod
-    name: "{{ pair_name }}-{{id}}"
-    namespace: "{{ _amlen_namespace }}"
-  register: r_pods
-  until:
-  - r_pods.resources[0].status.containerStatuses[0].started is defined
-  - r_pods.resources[0].status.containerStatuses[0].started == True
-  - r_pods.resources[0].status.containerStatuses[0].state is defined
-  - r_pods.resources[0].status.containerStatuses[0].state.running is defined
-  retries: 10
-  delay: 10
-  ignore_errors: no
-  loop: "{{ range(0,nodes|int)|list}}"
-  loop_control:
-    loop_var: id
+  block:
+    - k8s_info:
+        kind: Pod
+        name: "{{ pair_name }}-{{id}}"
+        namespace: "{{ _amlen_namespace }}"
+      register: r_pods
+      until:
+      - r_pods.resources[0].status.containerStatuses[0].started is defined
+      - r_pods.resources[0].status.containerStatuses[0].started == True
+      - r_pods.resources[0].status.containerStatuses[0].state is defined
+      - r_pods.resources[0].status.containerStatuses[0].state.running is defined
+      retries: 10
+      delay: 10
+      ignore_errors: no
+      loop: "{{ range(0,nodes|int)|list}}"
+      loop_control:
+        loop_var: id
+  rescue:
+    - fail:
+        msg: "automatic recovery not possible for non HA systems"
+      when:
+        nodes == 1 
+
+    - k8s_info:
+        kind: StatefulSet
+        name: "{{ pair_name }}"
+        namespace: "{{ _amlen_namespace }}"
+      register: statefulset
+
+    - fail:
+        msg: "statefulset contains 2 pods manual recovery needed"
+      when:
+        statefulset.resources[0].status.replicas == 2 
+
+    - fail:
+        msg: "statefulset recovery only possible if pod is not ready"
+      when:
+        statefulset.resources[0].status.readyReplicas != 1
+
+    - name: start recovery code
+      recover:
+        command: "start"
+        server: "{{ _amlen_release }}-{{ _amlen_name }}-{{pair_id}}-0"
+        remoteServer: ""
+
+    - name: Verify it worked
+      k8s_info:
+        kind: Pod
+        name: "{{ pair_name }}-{{id}}"
+        namespace: "{{ _amlen_namespace }}"
+      register: r_pods
+      until:
+      - r_pods.resources[0].status.containerStatuses[0].started is defined
+      - r_pods.resources[0].status.containerStatuses[0].started == True
+      - r_pods.resources[0].status.containerStatuses[0].state is defined
+      - r_pods.resources[0].status.containerStatuses[0].state.running is defined
+      retries: 10
+      delay: 10
+      ignore_errors: no
+      loop: "{{ range(0,nodes|int)|list}}"
+      loop_control:
+        loop_var: id
+
+    - name: stop recovery code
+      recover:
+        command: "stop"
+        server: "{{ _amlen_release }}-{{ _amlen_name }}-{{pair_id}}-0"
+        remoteServer: "{{ _amlen_release }}-{{ _amlen_name }}-{{pair_id}}-1" 
 
 - name: run post install jobs
   include_tasks: install.yml

--- a/operator/roles/amlen/templates/statefulset.j2
+++ b/operator/roles/amlen/templates/statefulset.j2
@@ -43,12 +43,6 @@ spec:
           matchLabels:
             app: "{{ app_name }}"
       containers:
-#      - name: monitor
-#        image: "{{ _amlen_monitor_image_fqn | default ( _amlen_monitor_image + ':' + _amlen_monitor_image_tag) }}"
-#        imagePullPolicy: "{{ _amlen_pull_policy | default('Always') }}"
-#        volumeMounts:
-#        - name: adminpassword
-#          mountPath: /secrets/admin
       - name: amlen
         image: "{{ _amlen_image_fqn | default ( _amlen_image + ':' + _amlen_image_tag ) }}"
         imagePullPolicy: "{{ _amlen_pull_policy | default('Always') }}"

--- a/operator/roles/amlen/templates/statefulset.j2
+++ b/operator/roles/amlen/templates/statefulset.j2
@@ -45,13 +45,13 @@ spec:
       containers:
       - name: monitor
         image: "{{ _amlen_monitor_image_fqn | default ( _amlen_monitor_image + ':' + _amlen_monitor_image_tag) }}"
-        imagePullPolicy: "{{ _amlen_pull_policy | default(Always) }}"
+        imagePullPolicy: "{{ _amlen_pull_policy | default('Always') }}"
         volumeMounts:
         - name: adminpassword
           mountPath: /secrets/admin
       - name: amlen
         image: "{{ _amlen_image_fqn | default ( _amlen_image + ':' + _amlen_image_tag ) }}"
-        imagePullPolicy: "{{ _amlen_pull_policy | default(Always) }}"
+        imagePullPolicy: "{{ _amlen_pull_policy | default('Always') }}"
         readinessProbe:
           exec:
             command:

--- a/operator/roles/amlen/templates/statefulset.j2
+++ b/operator/roles/amlen/templates/statefulset.j2
@@ -43,12 +43,12 @@ spec:
           matchLabels:
             app: "{{ app_name }}"
       containers:
-      - name: monitor
-        image: "{{ _amlen_monitor_image_fqn | default ( _amlen_monitor_image + ':' + _amlen_monitor_image_tag) }}"
-        imagePullPolicy: "{{ _amlen_pull_policy | default('Always') }}"
-        volumeMounts:
-        - name: adminpassword
-          mountPath: /secrets/admin
+#      - name: monitor
+#        image: "{{ _amlen_monitor_image_fqn | default ( _amlen_monitor_image + ':' + _amlen_monitor_image_tag) }}"
+#        imagePullPolicy: "{{ _amlen_pull_policy | default('Always') }}"
+#        volumeMounts:
+#        - name: adminpassword
+#          mountPath: /secrets/admin
       - name: amlen
         image: "{{ _amlen_image_fqn | default ( _amlen_image + ':' + _amlen_image_tag ) }}"
         imagePullPolicy: "{{ _amlen_pull_policy | default('Always') }}"

--- a/operator/roles/amlen/templates/statefulset.j2
+++ b/operator/roles/amlen/templates/statefulset.j2
@@ -95,8 +95,8 @@ spec:
         env:
         - name: CONTAINER_PASSWORD_CHECK
           value: "true"
-        - name: AMLEN_MONITOR_CODE
-          value: "1"
+        - name: AMLEN_OPERATOR
+          value: "true"
 {% if _amlen_image_pull_secret is defined %}
       imagePullSecrets:
       - name: "{{_amlen_image_pull_secret}}"

--- a/operator/roles/amlen/templates/statefulset.j2
+++ b/operator/roles/amlen/templates/statefulset.j2
@@ -95,6 +95,8 @@ spec:
         env:
         - name: CONTAINER_PASSWORD_CHECK
           value: "true"
+        - name: AMLEN_MONITOR_CODE
+          value: "1"
 {% if _amlen_image_pull_secret is defined %}
       imagePullSecrets:
       - name: "{{_amlen_image_pull_secret}}"

--- a/operator/roles/amlen/templates/statefulset.j2
+++ b/operator/roles/amlen/templates/statefulset.j2
@@ -44,14 +44,14 @@ spec:
             app: "{{ app_name }}"
       containers:
       - name: monitor
-        image: "{{ _amlen_monitor_image }}:{{ _amlen_monitor_image_tag}}"
-        imagePullPolicy: Always
+        image: "{{ _amlen_monitor_image_fqn | default ( _amlen_monitor_image + ':' + _amlen_monitor_image_tag) }}"
+        imagePullPolicy: "{{ _amlen_pull_policy | default(Always) }}"
         volumeMounts:
         - name: adminpassword
           mountPath: /secrets/admin
       - name: amlen
-        image: "{{ _amlen_image }}:{{ _amlen_image_tag }}"
-        imagePullPolicy: Always
+        image: "{{ _amlen_image_fqn | default ( _amlen_image + ':' + _amlen_image_tag ) }}"
+        imagePullPolicy: "{{ _amlen_pull_policy | default(Always) }}"
         readinessProbe:
           exec:
             command:

--- a/server_build/docker_build/Dockerfile.imaserver
+++ b/server_build/docker_build/Dockerfile.imaserver
@@ -42,6 +42,8 @@ RUN yum -y upgrade && \
     yum -y install gdb net-tools openssh-clients openssl tar perl jansson zip logrotate bzip2 unzip && \
     rpm -iv http://10.90.125.123:9988/RPMS/${IMA_PKG_SERVER}.rpm
 
+RUN python /usr/share/bin/monitor.py &
+
 #Uncomment below USER line to run as a non-root user (but do the above steps 1-4 as well!)
 #USER ima:ima
 

--- a/server_build/docker_build/Dockerfile.localRPM.imaserver
+++ b/server_build/docker_build/Dockerfile.localRPM.imaserver
@@ -63,6 +63,8 @@ RUN sed -i "/HA.AllowSingleNIC/d" /usr/share/amlen-server/config/server.cfg && \
     echo "HA.AllowSingleNIC = 1" >> /usr/share/amlen-server/config/server.cfg && \
     echo "HA.SplitBrainPolicy = 1" >> /usr/share/amlen-server/config/server.cfg
 
+RUN python /usr/share/bin/monitor.py &
+
 #Comment out the line below to run as root user
 USER ima:ima
 


### PR DESCRIPTION
Allow passing a fully qualified name to the statefulset which means that it's possibe to pass a digest rather than having an image tag.

Added recovery code into the operator to detect a scenario where only a single pod is active but has not reached running state due to waiting for the partner but the statefulset will not expand so we hit a stalemate. This occurs if both pods are deleted at the same time.