### PR TITLE
update operator version number

### DIFF
--- a/operator/config/manifests/bases/eclipse-amlen-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/eclipse-amlen-operator.clusterserviceversion.yaml
@@ -33,7 +33,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Streaming & Messaging
-    containerImage: quay.io/amlen/operator:v1.0.1a
+    containerImage: quay.io/amlen/operator:v1.0.1
     createdAt: "2022-11-24T15:31:00Z"
     description: An operator to run the Eclipse Amlen MQTT Broker
     operators.operatorframework.io/builder: operator-sdk-v1.25.2
@@ -211,7 +211,7 @@ spec:
                 env:
                 - name: ANSIBLE_GATHERING
                   value: explicit
-                image: quay.io/amlen/operator:v1.0.1a
+                image: quay.io/amlen/operator:v1.0.1
                 livenessProbe:
                   httpGet:
                     path: /healthz


### PR DESCRIPTION
Change the operator version in the bundle from the alpha v1.0.1a to v1.0.1

This doesn't impact the version used when installing from the redhat catalog as that is dependant on the version specified in https://github.com/redhat-openshift-ecosystem/community-operators-prod

This allows others to build catalogs by pointing at the bundle stored in:
https://quay.io/repository/amlen/operator-bundle