### PR TITLE
[patch] break up the utils_default memory category

### DIFF
--- a/server_protocol/src/jms.c
+++ b/server_protocol/src/jms.c
@@ -1738,7 +1738,7 @@ static void freeConsumer(ism_jms_prodcons_t * consumer) {
         ism_common_free(ism_memory_protocol_misc,consumer->name);
     if (consumer->rule)
     	//The rule is found via ism_common_compileSelectRule so is created by utils
-        ism_common_free(ism_memory_utils_misc,consumer->rule);
+        ism_common_free(ism_memory_utils_selector,consumer->rule);
     pthread_spin_destroy(&consumer->lock);
     ism_common_free(ism_memory_protocol_misc,consumer);
 }

--- a/server_utils/include/commonMemHandlerTypes.h
+++ b/server_utils/include/commonMemHandlerTypes.h
@@ -135,8 +135,19 @@ typedef struct tag_ism_common_memGroupInfo_t {
     ISM_COMMON_MEMORY_TYPE(ism_memory_saslScram,                 ism_memory_SaslScram,           "SaslSCRAM",                           commonMem_DuringLowMemEnabled)
     ISM_COMMON_MEMORY_TYPE(ism_memory_saslScramProfile,          ism_memory_SaslScram,           "SaslSCRAMProfile",                    commonMem_DuringLowMemEnabled)
     ISM_COMMON_MEMORY_TYPE(ism_memory_bufferPools,               ism_memory_Utilities,           "BufferPools",                         commonMem_DuringLowMemEnabled)
-
-    ///Add new types above this line... And don't forget to update the memory statistics routines (ism_common_getMemoryStatistics() in commonMemHandler.c) to include them...
+    ISM_COMMON_MEMORY_TYPE(ism_memory_utils_rehash,              ism_memory_Utilities,           "Certificate Rehashing",               commonMem_DuringLowMemEnabled)
+    ISM_COMMON_MEMORY_TYPE(ism_memory_utils_filter,              ism_memory_Utilities,           "Filters",                             commonMem_DuringLowMemEnabled)
+    ISM_COMMON_MEMORY_TYPE(ism_memory_utils_selector,            ism_memory_Utilities,           "Selectors",                           commonMem_DuringLowMemEnabled)
+    ISM_COMMON_MEMORY_TYPE(ism_memory_utils_props,               ism_memory_Utilities,           "Properties",                          commonMem_DuringLowMemEnabled)
+    ISM_COMMON_MEMORY_TYPE(ism_memory_utils_log,                 ism_memory_Utilities,           "Logging",                             commonMem_DuringLowMemEnabled)
+    ISM_COMMON_MEMORY_TYPE(ism_memory_utils_trace,               ism_memory_Utilities,           "Tracing",                             commonMem_DuringLowMemEnabled)
+    ISM_COMMON_MEMORY_TYPE(ism_memory_utils_map,                 ism_memory_Utilities,           "Hash maps",                           commonMem_DuringLowMemEnabled)
+    ISM_COMMON_MEMORY_TYPE(ism_memory_utils_array,               ism_memory_Utilities,           "Arrays",                              commonMem_DuringLowMemEnabled)
+    ISM_COMMON_MEMORY_TYPE(ism_memory_utils_list,                ism_memory_Utilities,           "Lists",                               commonMem_DuringLowMemEnabled)
+    ISM_COMMON_MEMORY_TYPE(ism_memory_utils_sslutils,            ism_memory_Utilities,           "SSL Utility Functions",               commonMem_DuringLowMemEnabled)
+    ISM_COMMON_MEMORY_TYPE(ism_memory_utils_xml,                 ism_memory_Utilities,           "XML Parsing",                         commonMem_DuringLowMemEnabled)
+    ISM_COMMON_MEMORY_TYPE(ism_memory_utils_throttle,            ism_memory_Utilities,           "Throttling",                          commonMem_DuringLowMemEnabled)
+    ///Add new types above this line... 
     ISM_COMMON_MEMORY_TYPE_END(ism_common_mem_numtypes)
 
 #undef ISM_COMMON_MEMORY_GROUP_START

--- a/server_utils/src/array.c
+++ b/server_utils/src/array.c
@@ -18,7 +18,7 @@
 #include <stdio.h>
 #include <assert.h>
 
-#define FREE(x)       if (x != NULL) { ism_common_free(ism_memory_utils_misc,x); x = NULL; }
+#define FREE(x)       if (x != NULL) { ism_common_free(ism_memory_utils_array,x); x = NULL; }
 static int arrayLockType = 1;
 struct ismUtilsArray_t
 {
@@ -60,7 +60,7 @@ static inline void arrayUnlock(ismArray_t array) {
 XAPI ismArray_t ism_common_createArray(uint32_t capacity) {
     ismArray_t array;
     uint32_t i;
-    if ((array = (ismArray_t) ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_misc,250),sizeof(struct ismUtilsArray_t)+(capacity*sizeof(uintptr_t)))) == NULL) {
+    if ((array = (ismArray_t) ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_array,250),sizeof(struct ismUtilsArray_t)+(capacity*sizeof(uintptr_t)))) == NULL) {
         return (NULL);
     }
     array->capacity = capacity;
@@ -96,7 +96,7 @@ XAPI void ism_common_destroyArrayAndFreeValues(ismArray_t array, ism_freeValueOb
     }
     pthread_spin_destroy(&(array->lock));
     pthread_mutex_destroy(&array->mutex);
-    ism_common_free(ism_memory_utils_misc,array);
+    ism_common_free(ism_memory_utils_array,array);
 }
 /*
  * Put an object into the list

--- a/server_utils/src/commonMemHandler.c
+++ b/server_utils/src/commonMemHandler.c
@@ -577,7 +577,7 @@ void ism_common_free_memaligned(ism_common_memoryType type, void *mem)
 /// @remark once posix_memalign is wrapped properly then this will adjust accounting
 ///        until then it just calls realloc
 //*************************************************************************
-void * ism_common_realloc_memaligned(ism_common_memoryType type, void *mem, size_t size)
+void * ism_common_realloc_memaligned(uint32_t probe, void *mem, size_t size)
 {
     return realloc(mem, size);
 }
@@ -812,8 +812,8 @@ void ism_common_traceMemoryStatistics( int32_t TraceLevel )
                 if ( total > 0 ) {
                     uint32_t typeId = 0;
                     for (typeId = 0; typeId < ism_common_mem_numtypes; typeId++) {
-                        if (ism_common_getMemoryGroupFromType(typeId) == groupId)
-                            TRACE(TraceLevel, "    Memory Type(%s) Used(%lu)\n", ism_common_getMemoryTypeName(typeId), memoryStats.types[typeId]);{
+                        if (ism_common_getMemoryGroupFromType(typeId) == groupId) {
+                            TRACE(TraceLevel, "    Memory Type(%s) Used(%lu)\n", ism_common_getMemoryTypeName(typeId), memoryStats.types[typeId]);
                         }
                     }
                 }

--- a/server_utils/src/filter.c
+++ b/server_utils/src/filter.c
@@ -567,13 +567,13 @@ struct ism_regex_t {
  * @return A regex specific return code
  */
 static inline int ism_regex_compile_withflags(ism_regex_t * pregex, const char * regex_str, int flags) {
-    ism_regex_t regex = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_misc,219),1, sizeof(regex_t));
+    ism_regex_t regex = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_filter,219),1, sizeof(regex_t));
     int     rc;
 
     rc = regcomp(&regex->regex, regex_str, flags);
     if (rc) {
         *pregex = NULL;
-        ism_common_free(ism_memory_utils_misc,regex);
+        ism_common_free(ism_memory_utils_filter,regex);
     } else {
         *pregex = regex;
     }
@@ -654,7 +654,7 @@ void ism_regex_free(ism_regex_t regex) {
     if (!regex)
         return;
    regfree(&regex->regex);
-   ism_common_free(ism_memory_utils_misc,regex);
+   ism_common_free(ism_memory_utils_filter,regex);
 }
 
 /*
@@ -2169,12 +2169,12 @@ ism_acl_t * ism_protocol_findACL(const char * name, int create, ismMessageSelect
             ism_protocol_lockACLList(true,lockStrategy);
             acl = ism_common_getHashMapElement(acl_list, name, namelen);
             if (!acl) {
-                acl = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_misc,222),1, sizeof(ism_acl_t) + namelen + 1);
+                acl = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_filter,222),1, sizeof(ism_acl_t) + namelen + 1);
                 if (acl) {
                     acl->hash = ism_common_createHashMap(100, HASH_STRING);
                     if (!acl->hash) {
                         ism_common_setError(ISMRC_AllocateError);
-                        ism_common_free(ism_memory_utils_misc,acl);
+                        ism_common_free(ism_memory_utils_filter,acl);
                         acl = NULL;
                     } else {
                         acl->name = (char *)(acl+1);
@@ -2286,7 +2286,7 @@ int ism_protocol_deleteACL(const char * name, ism_ACLcallback_f create_cb) {
         if (create_cb)
             create_cb(acl);
         ism_protocol_unlockACL(acl);
-        ism_common_free(ism_memory_utils_misc,acl);
+        ism_common_free(ism_memory_utils_filter,acl);
         return 0;
     } else {
         pthread_rwlock_unlock(&acl_lock);
@@ -2372,7 +2372,7 @@ static int check_acl_for_tenant(const char * name, const char * acl_name) {
 
     if (acl_name && (strlen(acl_name) > 2)) {
         if (strncmp(acl_name, acl_prefix, 2) == 0) {
-            acl_name_local = ism_common_strdup(ISM_MEM_PROBE(ism_memory_utils_misc,1000),acl_name);
+            acl_name_local = ism_common_strdup(ISM_MEM_PROBE(ism_memory_utils_filter,1000),acl_name);
 
             /* just check second token since we know it starts with a- */
             strtok(acl_name_local, sep);
@@ -2380,10 +2380,10 @@ static int check_acl_for_tenant(const char * name, const char * acl_name) {
 
             if (strcmp(name, acl_token) == 0) {
                 TRACE(8, "Found application acl: %s for tenant: %s\n", name, acl_name);
-                ism_common_free(ism_memory_utils_misc,acl_name_local);
+                ism_common_free(ism_memory_utils_filter,acl_name_local);
                 return 0;
             } else {
-                ism_common_free(ism_memory_utils_misc,acl_name_local);
+                ism_common_free(ism_memory_utils_filter,acl_name_local);
             }
         }
     }
@@ -2431,7 +2431,7 @@ int ism_rlac_deleteACL(const char * tenant_name) {
     TRACE(5, "Deleting any existing application acls for the tenant: %s\n", tenant_name);
 
     if (acl_list) {
-        filter_context = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_misc,227),1, sizeof(rlac_filter_context_t));
+        filter_context = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_filter,227),1, sizeof(rlac_filter_context_t));
         filter_context->name = tenant_name;
         filter_context->buf = &buf;
         ism_common_enumerateHashMap(acl_list, rlac_buf_callback, filter_context);
@@ -2445,7 +2445,7 @@ int ism_rlac_deleteACL(const char * tenant_name) {
         if (buf.inheap ) {
            ism_common_freeAllocBuffer(&buf);
         }
-        ism_common_free(ism_memory_utils_misc,filter_context);
+        ism_common_free(ism_memory_utils_filter,filter_context);
     }
     return 0;
 }
@@ -2481,7 +2481,7 @@ int ism_protocol_setACL(const char * aclsrc, int acllen, int opt, ism_ACLcallbac
     }
 
     /* Make a copy of the list and change CR or LF to NUL */
-    aclcopy = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_misc,229),acllen+2);
+    aclcopy = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_filter,229),acllen+2);
     memcpy(aclcopy, aclsrc, acllen);
     aclcopy[acllen] = 0;
     aclcopy[acllen+1] = 0xFF;
@@ -2590,7 +2590,7 @@ int ism_protocol_setACL(const char * aclsrc, int acllen, int opt, ism_ACLcallbac
         acl = NULL;
     }
     if (aclcopy)
-        ism_common_free(ism_memory_utils_misc,aclcopy);
+        ism_common_free(ism_memory_utils_filter,aclcopy);
     return rc;
 }
 
@@ -2611,7 +2611,7 @@ int ism_protocol_setACLfile2(const char * aclfile, ism_ACLcallback_f create_cb, 
         fseek(f, 0, SEEK_END);
         len = ftell(f);
         if (len > 0) {
-            buf = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_misc,231),len+2);
+            buf = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_filter,231),len+2);
         }
         if (!buf) {
             TRACE(4, "Unable to allocate memory for ACL file: %s\n", aclfile);
@@ -2627,7 +2627,7 @@ int ism_protocol_setACLfile2(const char * aclfile, ism_ACLcallback_f create_cb, 
         buf[bread] = 0;
         if (bread != len) {
             TRACE(4, "Unable to read the ACL file:%s\n", aclfile);
-            ism_common_free(ism_memory_utils_misc,buf);
+            ism_common_free(ism_memory_utils_filter,buf);
             fclose(f);
             return ISMRC_NotFound;
         }
@@ -2818,7 +2818,7 @@ mqtt_prop_ctx_t * ism_common_makeMqttPropCtx(mqtt_prop_field_t * idtbl, int vers
     max_array = max_id;
     if (max_array > 127)
         max_array = 127;
-    ctx = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_misc,233),1, sizeof(mqtt_prop_ctx_t) + (sizeof(mqtt_prop_field_t) * (max_array+1+more_count)));
+    ctx = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_filter,233),1, sizeof(mqtt_prop_ctx_t) + (sizeof(mqtt_prop_field_t) * (max_array+1+more_count)));
     ctx->version = version;
     ctx->array_id = max_array;
     ctx->max_id = max_id;
@@ -2850,7 +2850,7 @@ mqtt_prop_ctx_t * ism_common_makeMqttPropCtx(mqtt_prop_field_t * idtbl, int vers
  */
 int  ism_common_freeMqttPropCtx(mqtt_prop_ctx_t * ctx) {
     if (ctx)
-        ism_common_free(ism_memory_utils_misc,ctx);
+        ism_common_free(ism_memory_utils_filter,ctx);
     return 0;
 }
 

--- a/server_utils/src/ismlist.c
+++ b/server_utils/src/ismlist.c
@@ -23,7 +23,7 @@ int ism_common_list_init(ism_common_list *list, int synchronized, void (*destroy
      list->tail = NULL;
      list->destroy = destroy;
      if (synchronized) {
-      	list->lock = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_misc,203),sizeof(pthread_spinlock_t));
+      	list->lock = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_list,203),sizeof(pthread_spinlock_t));
     	if (list->lock == NULL)
       		return -1;
        	pthread_spin_init(list->lock,0);
@@ -47,7 +47,7 @@ static void removeAll(ism_common_list *list){
     	}
     	freeNode = pNode;
     	pNode = freeNode->next;
-    	ism_common_free(ism_memory_utils_misc,freeNode);
+    	ism_common_free(ism_memory_utils_list,freeNode);
     }
     list->head = list->tail = NULL;
     list->size = 0;
@@ -65,7 +65,7 @@ void ism_common_list_destroy(ism_common_list *list) {
     if (list->lock){
     	pthread_spin_unlock(list->lock);
     	pthread_spin_destroy(list->lock);
-    	ism_common_free(ism_memory_utils_misc,(void*)list->lock);
+    	ism_common_free(ism_memory_utils_list,(void*)list->lock);
     	list->lock = (void*)-1;
     }
 }
@@ -86,7 +86,7 @@ int ism_common_list_to_array(ism_common_list *list, void ***array) {
         	pthread_spin_unlock(list->lock);
     	return 0;
     }
-    *array = result = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_misc,206),list->size*(sizeof(void *)));
+    *array = result = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_list,206),list->size*(sizeof(void *)));
     if (result == NULL) {
         if (list->lock)
         	pthread_spin_unlock(list->lock);
@@ -101,7 +101,7 @@ int ism_common_list_to_array(ism_common_list *list, void ***array) {
 }
 
 #define INIT_NODE(NODE, DATA)  \
-	NODE = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_misc,207),1,sizeof(ism_common_list_node)); \
+	NODE = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_list,207),1,sizeof(ism_common_list_node)); \
 	if (NODE == NULL) \
 		return -1; \
 	NODE->data = (void *)DATA;
@@ -152,7 +152,7 @@ static int insertAfter(ism_common_list *list, ism_common_list_node * prevNode, i
 			ism_common_list_node * pNode = LIST->head; \
 			if (DATA) *DATA = pNode->data; \
 			LIST->head = pNode->next; \
-			ism_common_free(ism_memory_utils_misc,pNode); \
+			ism_common_free(ism_memory_utils_list,pNode); \
 			if (LIST->head) \
 				LIST->head->prev = NULL; \
 			else \
@@ -169,7 +169,7 @@ static int insertAfter(ism_common_list *list, ism_common_list_node * prevNode, i
 			if (DATA) \
                 *DATA = pNode->data; \
 			LIST->tail = pNode->prev; \
-			ism_common_free(ism_memory_utils_misc,pNode); \
+			ism_common_free(ism_memory_utils_list,pNode); \
 			if (LIST->tail) \
 			    LIST->tail->next = NULL; \
 			else \
@@ -225,7 +225,7 @@ int ism_common_list_from_array(ism_common_list *list, void **array, int size) {
     	int i;
     	retVal = 0;
     	for (i = 0; i < size; i++){
-			ism_common_list_node *newNode = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_misc,210),1,sizeof(ism_common_list_node));
+			ism_common_list_node *newNode = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_list,210),1,sizeof(ism_common_list_node));
 			if (!newNode){
 				retVal = -1;
 				break;
@@ -243,7 +243,7 @@ int ism_common_list_from_array(ism_common_list *list, void **array, int size) {
  *
  */
 XAPI void ism_common_list_array_free(void **array) {
-    ism_common_free(ism_memory_utils_misc,array);
+    ism_common_free(ism_memory_utils_list,array);
 }
 
 /*
@@ -428,7 +428,7 @@ int ism_common_list_remove(ism_common_list *list, ism_common_listIterator *iter,
     node->next->prev = node->prev;
     if (data)
         *data = node->data;
-    ism_common_free(ism_memory_utils_misc,node);
+    ism_common_free(ism_memory_utils_list,node);
     list->size--;
 	return 0;
 }

--- a/server_utils/src/logformat.c
+++ b/server_utils/src/logformat.c
@@ -739,7 +739,7 @@ void * ism_log_announcer(void * param, void * context, int value) {
         	}
         }
 
-        ism_common_free(ism_memory_utils_misc,logent);
+        ism_common_free(ism_memory_utils_log,logent);
     }
     return NULL;
 }
@@ -788,7 +788,7 @@ XAPI void ism_common_logInvoke(ism_common_log_context *context, const ISM_LOGLEV
     /*
      * Construct the log entry
      */
-    logent = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_misc,161),sizeof(ismLogEvent_t) + buf.used);
+    logent = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_log,161),sizeof(ismLogEvent_t) + buf.used);
     if (logent) {
         logent->timestamp = ism_common_currentTimeNanos();
         logent->category  = category;
@@ -816,7 +816,7 @@ XAPI void ism_common_logInvoke(ism_common_log_context *context, const ISM_LOGLEV
     if (!logent || g_logEntCount > LOG_ENT_MAX || (g_logEntLost && g_logEntCount > LOG_ENT_RESUME)) {
         g_logEntLost++;
         if (logent) {     /* If we made a logent, free it since we are not enqueuing it */
-            ism_common_free(ism_memory_utils_misc,logent);
+            ism_common_free(ism_memory_utils_log,logent);
         }
     } else {
         g_logEntCount++;
@@ -904,7 +904,7 @@ int ism_log_createLoggerSingle(ism_prop_t * props) {
     int   rc = 0;
     const char * type = ism_common_getStringProperty(props, "LogDestinationType");
     const char * destination = ism_common_getStringProperty(props, "LogDestination");
-    ism_logWriter_t * lw = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_misc,163),1, sizeof(ism_logWriter_t));
+    ism_logWriter_t * lw = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_log,163),1, sizeof(ism_logWriter_t));
 
     pthread_mutex_lock(&logLock);
 
@@ -987,7 +987,7 @@ XAPI int ism_log_createLogger(int which, ism_prop_t * props) {
 
 	TRACE(5, "Creating logger %s:%s\n", type, destination);
 
-    ism_logWriter_t * lw = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_misc,164),1, sizeof(ism_logWriter_t));
+    ism_logWriter_t * lw = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_log,164),1, sizeof(ism_logWriter_t));
 
     pthread_mutex_lock(&logLock);
 
@@ -1077,10 +1077,10 @@ XAPI int ism_log_updateLogger(int which, ism_prop_t * props) {
 	TRACE(5, "Creating logger %s:%s\n", type, destination);
 
     pthread_mutex_lock(&logLock);
-    ism_logWriter_t * lw = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_misc,165),sizeof(ism_logWriter_t));
+    ism_logWriter_t * lw = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_log,165),sizeof(ism_logWriter_t));
     memcpy(lw, g_logwriter[which], sizeof(ism_logWriter_t));
     if (g_logwriter[which]->destination && g_logwriter[which]->isfile) {
-    	lw->destination = ism_common_strdup(ISM_MEM_PROBE(ism_memory_utils_misc,1000),g_logwriter[which]->destination);
+    	lw->destination = ism_common_strdup(ISM_MEM_PROBE(ism_memory_utils_log,1000),g_logwriter[which]->destination);
     }
 
     int changed = 0;
@@ -1132,7 +1132,7 @@ XAPI int ism_log_updateLogger(int which, ism_prop_t * props) {
     		// file handle and destination pointer
     		if (oldlw->isfile && lw->desttype == DESTTYPE_SYSLOG) {
     			fclose(oldlw->file);
-    			ism_common_free(ism_memory_utils_misc,oldlw->destination);
+    			ism_common_free(ism_memory_utils_log,oldlw->destination);
 
     			g_logwriter[which]->isfile = 0;
     			g_logwriter[which]->destination = NULL;
@@ -1274,7 +1274,7 @@ static int destroyClientLogObj(ismClientLogObj * clientLogObj, char *keyStr)
 			ism_log_checkStructId(logObj->structId, ismLOG_LOGOBJ_STRUCTID);
 			msgcode=logObj->msgcode;
 			ism_log_invalidateStructId(logObj->structId);
-			ism_common_free(ism_memory_utils_misc,logObj);
+			ism_common_free(ism_memory_utils_log,logObj);
 			logObj=NULL;
 		}
 		removedCount++;
@@ -1288,7 +1288,7 @@ static int destroyClientLogObj(ismClientLogObj * clientLogObj, char *keyStr)
 	clientLogObj->msglogtable=NULL;
 
 	ism_log_invalidateStructId(clientLogObj->structId);
-	ism_common_free(ism_memory_utils_misc,clientLogObj);
+	ism_common_free(ism_memory_utils_log,clientLogObj);
 
 	ism_common_freeHashMapEntriesArray(dataEntries);
 
@@ -1373,7 +1373,7 @@ int ism_common_conditionallyLogged(ism_common_log_context *context, const ISM_LO
 
     if (clientLogItem==NULL) {
     	/*Initialize the clientLog Object*/
-    	clientLogObj= ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_misc,169),1,sizeof(ismClientLogObj));
+    	clientLogObj= ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_log,169),1,sizeof(ismClientLogObj));
     	ism_log_setStructId(clientLogObj->structId, ismLOG_CLIENTLOGOBJ_STRUCTID);
     	clientLogObj->msglogtable = ism_common_createHashMap(128,HASH_INT32);
 	    ism_common_putHashMapElement(g_logtable, key, keysize, clientLogObj, NULL);
@@ -1387,7 +1387,7 @@ int ism_common_conditionallyLogged(ism_common_log_context *context, const ISM_LO
 
     if (logItem==NULL){
 
-    	logObj= ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_misc,170),1,sizeof(ismLogObj));
+    	logObj= ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_log,170),1,sizeof(ismLogObj));
     	ism_log_setStructId(logObj->structId, ismLOG_LOGOBJ_STRUCTID);
 		logObj->msgcode = msgCode;
 		logObj->timestamp_last_logged=ctime;
@@ -1545,7 +1545,7 @@ static int logTableCleanUpTimerTask(ism_timer_t key, ism_time_t timestamp, void 
 					//Remove from the table.
 					ism_common_removeHashMapElement(clientLogObj->msglogtable, dataMsgLogEntries[msgloccount]->key, dataMsgLogEntries[msgloccount]->key_len);
 					ism_log_invalidateStructId(logObj->structId);
-					ism_common_free(ism_memory_utils_misc,logObj);
+					ism_common_free(ism_memory_utils_log,logObj);
 
 					msgLogRemovedCount++;
 					TRACE(7,"logTableCleanUpTimerTask: removed log object from the client log table: key=%s msgcode=%d totalremoved=%d\n", keyStr,msgcode, msgLogRemovedCount);

--- a/server_utils/src/logwriter.c
+++ b/server_utils/src/logwriter.c
@@ -161,18 +161,18 @@ void ism_log_toTrace(const ismLogOut_t * le) {
         if (buflen < 8192) {
             buf = alloca(buflen);
         } else {
-            buf = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_misc,142),buflen);
+            buf = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_log,142),buflen);
             inheap = 1;
         }
         bytes_needed = build_log_msg(le, 0, le->msgf, buf, buflen);
         if (bytes_needed > buflen) {
             if (inheap)
-                buf = ism_common_realloc(ISM_MEM_PROBE(ism_memory_utils_misc,143),buf, bytes_needed);
+                buf = ism_common_realloc(ISM_MEM_PROBE(ism_memory_utils_log,143),buf, bytes_needed);
             else {
                 if (bytes_needed < 8192 - buflen) {
                     buf = alloca(bytes_needed);
                 } else {
-                    buf = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_misc,144),bytes_needed);
+                    buf = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_log,144),bytes_needed);
                     inheap = 1;
                 }
             }
@@ -182,7 +182,7 @@ void ism_log_toTrace(const ismLogOut_t * le) {
         TRACE(6, "Log logid=%d from %s at %s:%d\n", le->msgnum, le->func, le->location, le->lineno);
         traceFunction(6, 0, le->location, le->lineno, "%s\n", buf);
         if (inheap)
-            ism_common_free(ism_memory_utils_misc,buf);
+            ism_common_free(ism_memory_utils_log,buf);
     }
 }
 
@@ -230,11 +230,11 @@ int ism_log_setWriterDestination(ism_logWriter_t * lw, const char * destination)
 
             lw->file = f;
             lw->isfile = isfile;
-            lw->destination = ism_common_strdup(ISM_MEM_PROBE(ism_memory_utils_misc,1000),destination);
+            lw->destination = ism_common_strdup(ISM_MEM_PROBE(ism_memory_utils_log,1000),destination);
 
             if (oldIsFile) {
                 fclose(oldFile);
-                ism_common_free(ism_memory_utils_misc,oldDestination);
+                ism_common_free(ism_memory_utils_log,oldDestination);
             }
         }
     }
@@ -246,7 +246,7 @@ int ism_log_setWriterDestination(ism_logWriter_t * lw, const char * destination)
  */
 void ism_log_closeWriter(ism_logWriter_t * lw) {
     if (lw) {
-        ism_common_free(ism_memory_utils_misc,lw);
+        ism_common_free(ism_memory_utils_log,lw);
         lw = NULL;
     }
 }
@@ -308,19 +308,19 @@ void ism_log_toISMLogger(ism_logWriter_t * lw, int kind, ismLogOut_t * logout) {
     if (buflen < 8192) {
         buf = alloca(buflen);
     } else {
-        buf = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_misc,148),buflen);
+        buf = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_log,148),buflen);
         inheap = 1;
     }
     if (lw->desttype == DESTTYPE_FILE) {
         bytes_needed = build_log_msg(logout, 0, msgf, buf, buflen);
         if (bytes_needed > buflen) {
             if (inheap)
-                buf = ism_common_realloc(ISM_MEM_PROBE(ism_memory_utils_misc,149),buf, bytes_needed);
+                buf = ism_common_realloc(ISM_MEM_PROBE(ism_memory_utils_log,149),buf, bytes_needed);
             else {
                 if (bytes_needed < 8192 - buflen) {
                     buf = alloca(bytes_needed);
                 } else {
-                    buf = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_misc,150),bytes_needed);
+                    buf = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_log,150),bytes_needed);
                     inheap = 1;
                 }
             }
@@ -345,12 +345,12 @@ void ism_log_toISMLogger(ism_logWriter_t * lw, int kind, ismLogOut_t * logout) {
         bytes_needed = build_log_msg(logout, pri, msgf, buf, buflen);
         if (bytes_needed > buflen) {
             if (inheap)
-                buf = ism_common_realloc(ISM_MEM_PROBE(ism_memory_utils_misc,151),buf, bytes_needed);
+                buf = ism_common_realloc(ISM_MEM_PROBE(ism_memory_utils_log,151),buf, bytes_needed);
             else {
                 if (bytes_needed < 8192 - buflen) {
                     buf = alloca(bytes_needed);
                 } else {
-                    buf = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_misc,152),bytes_needed);
+                    buf = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_log,152),bytes_needed);
                     inheap = 1;
                 }
             }
@@ -364,7 +364,7 @@ void ism_log_toISMLogger(ism_logWriter_t * lw, int kind, ismLogOut_t * logout) {
         callback(buf);
     }
     if (inheap)
-        ism_common_free(ism_memory_utils_misc,buf);
+        ism_common_free(ism_memory_utils_log,buf);
 }
 
 /*
@@ -601,13 +601,13 @@ int ism_log_initSyslog(ism_prop_t * props) {
 
     // Try to establish syslog connection using specified configuration
     // If successful, update syslogConnection object
-    ismSyslogConnection_t * tempConnection = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_misc,154),1, sizeof(ismSyslogConnection_t));
+    ismSyslogConnection_t * tempConnection = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_log,154),1, sizeof(ismSyslogConnection_t));
     if (host) {
-        tempConnection->ip = ism_common_strdup(ISM_MEM_PROBE(ism_memory_utils_misc,1000),host);
+        tempConnection->ip = ism_common_strdup(ISM_MEM_PROBE(ism_memory_utils_log,1000),host);
     } else if (syslogConnection && syslogConnection->ip) {
-        tempConnection->ip = ism_common_strdup(ISM_MEM_PROBE(ism_memory_utils_misc,1000),syslogConnection->ip);
+        tempConnection->ip = ism_common_strdup(ISM_MEM_PROBE(ism_memory_utils_log,1000),syslogConnection->ip);
     } else {
-        tempConnection->ip = ism_common_strdup(ISM_MEM_PROBE(ism_memory_utils_misc,1000),DUMMY_LINKLOCAL_ADDR);
+        tempConnection->ip = ism_common_strdup(ISM_MEM_PROBE(ism_memory_utils_log,1000),DUMMY_LINKLOCAL_ADDR);
     }
 
     if (port != -1) {
@@ -628,8 +628,8 @@ int ism_log_initSyslog(ism_prop_t * props) {
     rc = ism_log_openSysLogConnection(tempConnection);
     if (rc) {
         ism_log_closeSysLogConnection(tempConnection);
-        ism_common_free(ism_memory_utils_misc,(char*)tempConnection->ip);
-        ism_common_free(ism_memory_utils_misc,tempConnection);
+        ism_common_free(ism_memory_utils_log,(char*)tempConnection->ip);
+        ism_common_free(ism_memory_utils_log,tempConnection);
 
         return rc;
     }
@@ -648,7 +648,7 @@ int ism_log_initSyslog(ism_prop_t * props) {
         syslogConnection->isconnected = 0;
 
         if (strcmp(tempConnection->ip, syslogConnection->ip)) {
-            ism_common_free(ism_memory_utils_misc,(char*)syslogConnection->ip);
+            ism_common_free(ism_memory_utils_log,(char*)syslogConnection->ip);
             syslogConnection->ip = tempConnection->ip;
         }
         syslogConnection->port = tempConnection->port;
@@ -657,7 +657,7 @@ int ism_log_initSyslog(ism_prop_t * props) {
         rc = ism_log_openSysLogConnection(syslogConnection);
     }
 
-    ism_common_free(ism_memory_utils_misc,tempConnection);
+    ism_common_free(ism_memory_utils_log,tempConnection);
 
     return rc;
 }
@@ -717,7 +717,7 @@ static ismFilterItem_t * insertFilterItem(uint32_t value, uint32_t level, uint32
             *max = 32;
         else
             *max = *max * 4;
-        vals = ism_common_realloc(ISM_MEM_PROBE(ism_memory_utils_misc,159),vals, *max * sizeof(ismFilterItem_t));
+        vals = ism_common_realloc(ISM_MEM_PROBE(ism_memory_utils_log,159),vals, *max * sizeof(ismFilterItem_t));
 
         vals[(*count)].level = level;
         vals[(*count)].kind = kind;

--- a/server_utils/src/map.c
+++ b/server_utils/src/map.c
@@ -25,7 +25,7 @@
 #define FNV_OFFSET_BASIS_32 0x811C9DC5
 #define FNV_PRIME_32 0x1000193
 
-#define FREE(x)       if (x != NULL) { ism_common_free(ism_memory_utils_misc,x); x = NULL; }
+#define FREE(x)       if (x != NULL) { ism_common_free(ism_memory_utils_map,x); x = NULL; }
 //#define MAP_DEBUG
 typedef uint32_t (* hash_func_t)(const void * in, size_t *lens);
 struct ismHashMap_t
@@ -128,7 +128,7 @@ static void HM_resize_map(ismHashMap *hash_map) {
     if (hash_map->capacity > 0xFFFFFF)
         return;
 
-    if ((elements = (ismHashMapEntry **)ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_misc,135),2 * hash_map->capacity, sizeof(ismHashMapEntry *))) == NULL) {
+    if ((elements = (ismHashMapEntry **)ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_map,135),2 * hash_map->capacity, sizeof(ismHashMapEntry *))) == NULL) {
         return;
     }
     prev_capacity = hash_map->capacity;
@@ -153,7 +153,7 @@ static void HM_resize_map(ismHashMap *hash_map) {
         }
     }
 
-    ism_common_free(ism_memory_utils_misc,hash_map->elements);
+    ism_common_free(ism_memory_utils_map,hash_map->elements);
     hash_map->elements = elements;
 }
 
@@ -175,7 +175,7 @@ XAPI uint32_t ism_common_computeHashCode(const char * ptr, size_t length) {
 XAPI ismHashMap *ism_common_createHashMap(uint32_t capacity, ismHashFunctionType_t hashType) {
     ismHashMap *hash_map;
 
-    if ((hash_map = (ismHashMap *) ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_misc,137),1, sizeof(ismHashMap))) == NULL) {
+    if ((hash_map = (ismHashMap *) ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_map,137),1, sizeof(ismHashMap))) == NULL) {
         return (NULL);
     }
     if (capacity < 0x1000000) {
@@ -188,7 +188,7 @@ XAPI ismHashMap *ism_common_createHashMap(uint32_t capacity, ismHashFunctionType
         hash_map->capacity = 0x1000000;
     }
 
-    if ((hash_map->elements = (ismHashMapEntry **) ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_misc,138),hash_map->capacity, sizeof(ismHashMapEntry *))) == NULL) {
+    if ((hash_map->elements = (ismHashMapEntry **) ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_map,138),hash_map->capacity, sizeof(ismHashMapEntry *))) == NULL) {
         FREE(hash_map);
         return (NULL);
     }
@@ -233,7 +233,7 @@ XAPI void ism_common_destroyHashMapAndFreeValues(ismHashMap * hash_map, ism_free
             lle_next = lle->next;
             if(lle->value && freeCB)
             	freeCB(lle->value);
-            ism_common_free(ism_memory_utils_misc,lle);
+            ism_common_free(ism_memory_utils_map,lle);
             lle = lle_next;
         }
     }
@@ -276,7 +276,7 @@ XAPI int ism_common_putHashMapElement(ismHashMap *hash_map, const void *key, int
     hash_code = hash_map->hashFunc(key, &keyLen);
     index = hash_code & hash_map->mask;
 
-    if ((new_lle = (ismHashMapEntry *) ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_misc,140),sizeof(ismHashMapEntry) + keyLen)) == NULL) {
+    if ((new_lle = (ismHashMapEntry *) ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_map,140),sizeof(ismHashMapEntry) + keyLen)) == NULL) {
         return (-1);
     }
 
@@ -596,7 +596,7 @@ int ism_common_getHashMapNumElements(const ismHashMap *hash_map) {
  * @return the array with all entries in the map. Last element of the array is (void*)-1;
  */
 ismHashMapEntry ** ism_common_getHashMapEntriesArray(ismHashMap * hash_map) {
-    ismHashMapEntry ** result = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_misc,141),(hash_map->nelements + 1) * sizeof(ismHashMapEntry*));
+    ismHashMapEntry ** result = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_map,141),(hash_map->nelements + 1) * sizeof(ismHashMapEntry*));
     ismHashMapEntry *hme;
     int index;
     int counter = 0;

--- a/server_utils/src/properties.c
+++ b/server_utils/src/properties.c
@@ -58,7 +58,7 @@ ism_prop_t * ism_common_newProperties(int count) {
     if (bufsize < 1000)
         bufsize = 1000;
     size = sizeof(ism_prop_t) + count * sizeof(ism_propent_t) + bufsize;
-    ret = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_misc,128),size);
+    ret = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_props,128),size);
     memset(ret, 0, sizeof(ism_prop_t));
     ret->props = (ism_propent_t *)(ret+1);
     ret->suballoc.size = size-sizeof(ism_prop_t);
@@ -85,7 +85,7 @@ static char * allocPropertyBytes(ism_prop_t * props, int len, int align) {
         }
         if (!suba->next) {
             int newlen = ((len+1200+sizeof(struct suballoc_t)) & ~0x3ff) - 16; /* 16 -s the malloc overhead. for small allocations the ideal size is power of 2 - 16 */
-            suba->next = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_misc,129),newlen);
+            suba->next = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_props,129),newlen);
             suba->next->next = 0;
             suba->next->size = newlen-sizeof(struct suballoc_t);
             suba->next->pos  = 0;
@@ -108,9 +108,9 @@ void ism_common_freeProperties(ism_prop_t * props) {
             struct suballoc_t * freesub = suba;
             suba = suba->next;
             freesub->next = NULL;
-            ism_common_free(ism_memory_utils_misc,freesub);
+            ism_common_free(ism_memory_utils_props,freesub);
         }
-        ism_common_free(ism_memory_utils_misc,props);
+        ism_common_free(ism_memory_utils_props,props);
     }
 }
 
@@ -547,7 +547,7 @@ int ism_common_clearProperties(ism_prop_t * props) {
         struct suballoc_t * freesub = suba;
         suba = suba->next;
         freesub->next = NULL;
-        ism_common_free(ism_memory_utils_misc,freesub);
+        ism_common_free(ism_memory_utils_props,freesub);
     }
     props->suballoc.next = NULL;
 	props->propcount = 0;

--- a/server_utils/src/rehash.c
+++ b/server_utils/src/rehash.c
@@ -92,7 +92,7 @@ static int getFileContent(const char * path, const char * name, char * * xbuf, i
     fseek(f, 0, SEEK_END);
     len =  ftell(f);
     if (len >= 0 && len < maxsize) {
-        buf = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_misc,122),len+1);
+        buf = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_rehash,122),len+1);
         if (buf) {
             buf[len] = 0;
             rewind(f);
@@ -162,11 +162,11 @@ static int linkHashLink(file_hash_t * hash, const char * dirpath, const char * t
         for (i=0; i<targetcount; i++) {
             /* If it already points to a file containing this fingerprint, no link is required */
             if (!memcmp(targethash[i].fingerprint, hash->fingerprint, sizeof(hash->fingerprint))) {
-                ism_common_free(ism_memory_utils_misc,targethash);
+                ism_common_free(ism_memory_utils_rehash,targethash);
                 return 0;
             }
         }
-        ism_common_free(ism_memory_utils_misc,targethash);
+        ism_common_free(ism_memory_utils_rehash,targethash);
         unique++;
         sprintf(hashfile, (hash->kind == 'r' ? "%s.r%d" : "%s.%d"), hash->hash, unique);
     }
@@ -276,14 +276,14 @@ static int doTrustFile(const char * dirpath, const char * name, file_hash_t * * 
 
     /* If this is a PEM file, return the hash and fingerprint objects we found */
     if (hashcount) {
-        file_hash_t * ret = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_misc,125),hashcount * sizeof(file_hash_t));
+        file_hash_t * ret = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_rehash,125),hashcount * sizeof(file_hash_t));
         memcpy(ret, hashes, hashcount * sizeof(file_hash_t));
         *hash = ret;
     }
 
     /* Free up the buffer containing the file */
     if (filebuf)
-        ism_common_free(ism_memory_utils_misc,filebuf);
+        ism_common_free(ism_memory_utils_rehash,filebuf);
     return hashcount;
 }
 
@@ -344,7 +344,7 @@ int  ism_common_hashTrustDirectory(const char * dirpath, int leave_links, int ve
                     for (i=0; i<hashcount; i++) {
                         addcount += linkHashLink(hash+i, dirpath, dent->d_name, verbose);
                     }
-                    ism_common_free(ism_memory_utils_misc,hash);
+                    ism_common_free(ism_memory_utils_rehash,hash);
                 }
             }
             dent = readdir(dp);

--- a/server_utils/src/selector.c
+++ b/server_utils/src/selector.c
@@ -744,25 +744,25 @@ int ism_common_compileSelectRuleOpt(ismRule_t * * xrule, int * outlen, const cha
 	memset(rulec, 0, sizeof(rulex));
 	rulec->ruledef = (char *)ruledef;
 	rulec->buflen = 64*1024;
-	rulec->buf = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_misc,116),rulec->buflen);
+	rulec->buf = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_selector,116),rulec->buflen);
 	if (options&SELOPT_Internal)
 	    rulec->opt_internal = 1;
 	rulec->options = (uint16_t)options;
-	token = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_misc,117),tokenlen);
+	token = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_selector,117),tokenlen);
 
 	if (ruledef == NULL)
 	    ruledef = "";
 	rulec->ruledef = (char *)ruledef;
 	rc = compile(rulec, token, tokenlen);
 	if (rc == 0) {
-	    ret = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_misc,118),rulec->bufpos);
+	    ret = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_selector,118),rulec->bufpos);
 	    memcpy(ret, rulec->buf, rulec->bufpos);
 	    *xrule = ret;
 	    if (outlen)
 	        *outlen = rulec->bufpos;
 	}
-	ism_common_free(ism_memory_utils_misc,rulec->buf);
-	ism_common_free(ism_memory_utils_misc,token);
+	ism_common_free(ism_memory_utils_selector,rulec->buf);
+	ism_common_free(ism_memory_utils_selector,token);
 	return rc;
 }
 
@@ -1271,7 +1271,7 @@ static const char * opname(int op, int kind) {
  */
 void ism_common_freeSelectRule(ismRule_t * rule) {
     if (rule) {
-        ism_common_free(ism_memory_utils_misc,rule);
+        ism_common_free(ism_memory_utils_selector,rule);
     }
 }
 

--- a/server_utils/src/ssl.c
+++ b/server_utils/src/ssl.c
@@ -359,7 +359,7 @@ static int readPSKFile(FILE * fin, ismHashMap * map) {
         }
 		if (key) {
 		    int keylen;
-		    binkey = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_misc,63),strlen(key)/2 + 1);
+		    binkey = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_sslutils,63),strlen(key)/2 + 1);
 		    keylen = ism_common_fromHexString(key, binkey+1);
 		    if (keylen < 0 || keylen > 256) {
 		        TRACE(8, "PSK key conversion failed on line %d:  \"%s\"\n", lineCounter, key);
@@ -372,7 +372,7 @@ static int readPSKFile(FILE * fin, ismHashMap * map) {
 		            key = ism_common_removeHashMapElement(map, id, 0);
 		            if (key) {
 		                TRACEX(9, TLS, 0, "Remove PSK: identity=%s\n", id);
-		                ism_common_free(ism_memory_utils_misc,key);
+		                ism_common_free(ism_memory_utils_sslutils,key);
 		            }
 		        }
 		    }
@@ -389,7 +389,7 @@ static void freePSKMap(ismHashMap * map) {
 	ismHashMapEntry **entries = ism_common_getHashMapEntriesArray(map);
 	int count = 0;
 	while (entries[count] != ((void*) -1)) {
-		ism_common_free(ism_memory_utils_misc,entries[count]->value);
+		ism_common_free(ism_memory_utils_sslutils,entries[count]->value);
 		count++;
 	}
 	ism_common_freeHashMapEntriesArray(entries);
@@ -514,7 +514,7 @@ static int addAllowedClientCert(ismHashMap * map, const char * crtFileName) {
         sslGatherErr(&buf);
         TRACE(4, "Unable to parse client certificate %s: %s\n", crtFileName, buf.buf);
         if (buf.inheap)
-            ism_common_free(ism_memory_utils_misc,buf.buf);
+            ism_common_free(ism_memory_utils_sslutils,buf.buf);
         return 0;
     }
     hash = X509_subject_name_hash(cert);
@@ -2200,7 +2200,7 @@ static void freeTrustedCertCB(void *data) {
             if (certData->pkey)
                 EVP_PKEY_free(certData->pkey);
             ism_common_list_destroy(&certData->crlLocations);
-            ism_common_free(ism_memory_utils_misc,certData);
+            ism_common_free(ism_memory_utils_sslutils,certData);
         }
     }
 }
@@ -2227,7 +2227,7 @@ static inline BIO * createReadBIO(const char * buf, int length, char ** extraBuf
 
 /* Free entry of admin action list */
 void ssl_free_data(void *data) {
-    ism_common_free(ism_memory_utils_misc,data);
+    ism_common_free(ism_memory_utils_sslutils,data);
 }
 
 
@@ -2236,7 +2236,7 @@ void ssl_free_data(void *data) {
  */
 static int readCerts(const char * certs, int length, ism_common_list * certList, int trusted) {
     BIO * certdata = NULL;
-    char * buf = ism_common_strdup(ISM_MEM_PROBE(ism_memory_utils_misc,1000),certs);
+    char * buf = ism_common_strdup(ISM_MEM_PROBE(ism_memory_utils_sslutils,1000),certs);
     char * extrabuf = NULL;
     if (trusted) {
         ism_common_list_init(certList, 0, freeTrustedCertCB);
@@ -2252,7 +2252,7 @@ static int readCerts(const char * certs, int length, ism_common_list * certList,
     }
 
     if (length < 1) {
-        ism_common_free(ism_memory_utils_misc,buf);
+        ism_common_free(ism_memory_utils_sslutils,buf);
         return ISMRC_CertificateNotValid;
     }
 
@@ -2262,7 +2262,7 @@ static int readCerts(const char * certs, int length, ism_common_list * certList,
         int rc = ISMRC_OK;
         while (!BIO_eof(certdata)) {
             if (trusted) {
-                sslTrustCertData_t * tcd = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_misc,72),sizeof(sslTrustCertData_t));
+                sslTrustCertData_t * tcd = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_sslutils,72),sizeof(sslTrustCertData_t));
                 if (tcd) {
                     X509 * cert = PEM_read_bio_X509_AUX(certdata, NULL, NULL, NULL);
                     if (cert) {
@@ -2278,17 +2278,17 @@ static int readCerts(const char * certs, int length, ism_common_list * certList,
                             traceSSLError("Failed to extract public key ");
                             X509_free(cert);
                             BIO_free(certdata);
-                            ism_common_free(ism_memory_utils_misc,buf);
+                            ism_common_free(ism_memory_utils_sslutils,buf);
                             return ISMRC_CertificateNotValid;
                         }
                     } else {
                         err = ERR_peek_last_error();
                     }
-                    ism_common_free(ism_memory_utils_misc,tcd);
+                    ism_common_free(ism_memory_utils_sslutils,tcd);
                     break;
                 } else {
                     BIO_free(certdata);
-                    ism_common_free(ism_memory_utils_misc,buf);
+                    ism_common_free(ism_memory_utils_sslutils,buf);
                     return ISMRC_AllocateError;
                 }
             } else {
@@ -2307,14 +2307,14 @@ static int readCerts(const char * certs, int length, ism_common_list * certList,
             rc = ISMRC_CertificateNotValid;
         }
         BIO_free(certdata);
-        ism_common_free(ism_memory_utils_misc,buf);
+        ism_common_free(ism_memory_utils_sslutils,buf);
         if (extrabuf)
-            ism_common_free(ism_memory_utils_misc,extrabuf);
+            ism_common_free(ism_memory_utils_sslutils,extrabuf);
         return rc;
     }
-    ism_common_free(ism_memory_utils_misc,buf);
+    ism_common_free(ism_memory_utils_sslutils,buf);
     if (extrabuf)
-        ism_common_free(ism_memory_utils_misc,extrabuf);
+        ism_common_free(ism_memory_utils_sslutils,extrabuf);
     return ISMRC_AllocateError;
 }
 
@@ -2335,11 +2335,11 @@ static int readKey(const char * buf, int length, EVP_PKEY ** pKey) {
         *pKey = key;
         BIO_free(keydata);
         if (extrabuf)
-            ism_common_free(ism_memory_utils_misc,extrabuf);
+            ism_common_free(ism_memory_utils_sslutils,extrabuf);
         return rc;
     }
     if (extrabuf)
-        ism_common_free(ism_memory_utils_misc,extrabuf);
+        ism_common_free(ism_memory_utils_sslutils,extrabuf);
     return ISMRC_AllocateError;
 }
 
@@ -2365,7 +2365,7 @@ static X509_CRL * readCRL(const char * buf, int length) {
         ism_common_setError(ISMRC_AllocateError);
     }
     if (extrabuf)
-        ism_common_free(ism_memory_utils_misc,extrabuf);
+        ism_common_free(ism_memory_utils_sslutils,extrabuf);
     return result;
 }
 #endif
@@ -2655,7 +2655,7 @@ static int parseCrlLocations(X509 * cert, ism_common_list * crlLocations) {
                         for (j = 0; j < sk_GENERAL_NAME_num(dp->distpoint->name.fullname); j++) {
                             GENERAL_NAME *gn = sk_GENERAL_NAME_value(dp->distpoint->name.fullname, j);
                             if (gn != NULL && gn->type == GEN_URI) {
-                                const char * uri = ism_common_strdup(ISM_MEM_PROBE(ism_memory_utils_misc,1000),(const char *) gn->d.ia5->data);
+                                const char * uri = ism_common_strdup(ISM_MEM_PROBE(ism_memory_utils_sslutils,1000),(const char *) gn->d.ia5->data);
                                 if (uri == NULL) {
                                     rc = ISMRC_AllocateError;
                                     break;
@@ -2807,20 +2807,20 @@ static void freeOrgConfig(const char * name) {
                 SSL_CTX_free(orgConfig->ctx);
             }
             if (orgConfig->serverCert) {
-                ism_common_free(ism_memory_utils_misc,orgConfig->serverCert);
+                ism_common_free(ism_memory_utils_sslutils,orgConfig->serverCert);
             }
             if (orgConfig->serverKey) {
-                ism_common_free(ism_memory_utils_misc,orgConfig->serverKey);
+                ism_common_free(ism_memory_utils_sslutils,orgConfig->serverKey);
             }
             if (orgConfig->trustCerts) {
-                ism_common_free(ism_memory_utils_misc,orgConfig->trustCerts);
+                ism_common_free(ism_memory_utils_sslutils,orgConfig->trustCerts);
                 ism_common_list_destroy(&orgConfig->trustCertsList);
             }
             if (orgConfig->name) {
-                ism_common_free(ism_memory_utils_misc,(char *)orgConfig->name);
+                ism_common_free(ism_memory_utils_sslutils,(char *)orgConfig->name);
             }
             pthread_mutex_destroy(&orgConfig->lock);
-            ism_common_free(ism_memory_utils_misc,orgConfig);
+            ism_common_free(ism_memory_utils_sslutils,orgConfig);
             ism_common_removeHashMapElement(orgConfigMap, name, 0);
         }
     }
@@ -2834,7 +2834,7 @@ typedef struct crlUpdateTask_t {
 
 
 xUNUSED static crlUpdateTask_t * createUpdateCRLTask(const char * orgname, uint32_t generation) {
-    crlUpdateTask_t * task = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_misc,88),sizeof(crlUpdateTask_t) + strlen(orgname) + 1);
+    crlUpdateTask_t * task = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_sslutils,88),sizeof(crlUpdateTask_t) + strlen(orgname) + 1);
     if (task) {
         task->orgName = (char *)(task + 1);
         strcpy((char*) task->orgName, orgname);
@@ -2882,7 +2882,7 @@ int ism_ssl_waitPendingCRL(ima_transport_info_t * transport, const char * org, v
                     TRACE(8, "call wait callback: connect=%d rc=%s (%d)\n", transport->index,
                             X509_verify_cert_error_string(waiter->verify_rc), waiter->verify_rc);
                     waitcb(waiter->verify_rc, data);
-                    ism_common_free(ism_memory_utils_misc,waiter);
+                    ism_common_free(ism_memory_utils_sslutils,waiter);
                     waiter = NULL;
                 }
                 break;
@@ -2910,7 +2910,7 @@ int ism_ssl_waitPendingCRL(ima_transport_info_t * transport, const char * org, v
  * Create a new CRL name
  */
 static tlsCrl_t * newCrlObj(const char * crlname) {
-    tlsCrl_t * ret = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_misc,90),1, sizeof(tlsCrl_t) + strlen(crlname)+1);
+    tlsCrl_t * ret = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_sslutils,90),1, sizeof(tlsCrl_t) + strlen(crlname)+1);
     ret->name = (const char *)(ret+1);
     strcpy((char *)ret->name, crlname);
     ret->inprocess = 1;
@@ -2925,7 +2925,7 @@ int ism_ssl_test_addWaiter(ima_transport_info_t * transport, const char * org) {
     tlsCrlWait_t * waiter;
     tlsOrgConfig_t * orgConfig = ism_common_getHashMapElement(orgConfigMap, org, 0);
     if (orgConfig) {
-        waiter = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_misc,91),1, sizeof(tlsCrlWait_t));
+        waiter = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_sslutils,91),1, sizeof(tlsCrlWait_t));
         waiter->transport = transport;
         waiter->transport_ssl = transport->ssl;
         waiter->rc = ISMRC_AsyncCompletion;
@@ -2996,7 +2996,7 @@ int ism_ssl_needCRL(ima_transport_info_t * transport, const char * org, X509 * c
             }
 
             /* Construct the waiter object */
-            waiter = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_misc,92),1, sizeof(tlsCrlWait_t) + len + count*sizeof(void *));
+            waiter = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_sslutils,92),1, sizeof(tlsCrlWait_t) + len + count*sizeof(void *));
             char * data = (char *)(waiter+1);
             data += count * sizeof(void *);
             waiter->transport = transport;
@@ -3055,7 +3055,7 @@ int ism_ssl_needCRL(ima_transport_info_t * transport, const char * org, X509 * c
                     oldwaiter->next = waiter;
                 }
             } else {
-                ism_common_free(ism_memory_utils_misc,waiter);
+                ism_common_free(ism_memory_utils_sslutils,waiter);
             }
 
             /* Schedule the update */
@@ -3291,7 +3291,7 @@ int ism_ssl_stopCrlWait(ima_transport_info_t * transport, const char * org) {
                         else
                             orgConfig->waiters = waiter->next;
                         nextwaiter = waiter->next;
-                        ism_common_free(ism_memory_utils_misc,waiter);
+                        ism_common_free(ism_memory_utils_sslutils,waiter);
                         ret++;
                     } else {
                         oldwaiter = waiter;
@@ -3369,7 +3369,7 @@ static void releaseCrlWaiters(tlsOrgConfig_t * orgConfig, tlsCrl_t * crlobj) {
                 else
                     orgConfig->waiters = waiter->next;
                 tlsCrlWait_t * nextwaiter = waiter->next;
-                ism_common_free(ism_memory_utils_misc,waiter);
+                ism_common_free(ism_memory_utils_sslutils,waiter);
                 waiter = nextwaiter;
             } else {
                 oldwaiter = waiter;
@@ -3512,7 +3512,7 @@ static int processCRLUpdate(crlUpdateTask_t * task) {
         freeOrgConfig(task->orgName);    /* Decrement the use count */
     } else {
         rc = 1;
-        ism_common_free(ism_memory_utils_misc,task);
+        ism_common_free(ism_memory_utils_sslutils,task);
         ism_common_HashMapUnlock(orgConfigMap);
     }
     return rc;
@@ -3660,9 +3660,9 @@ int ism_ssl_setSNIConfig(const char * name, const char * serverCert, const char 
     ism_common_HashMapLock(orgConfigMap);
     tlsOrgConfig_t * orgConfig = ism_common_getHashMapElement(orgConfigMap, name, 0);
     if (orgConfig == NULL) {
-        orgConfig = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_misc,97),1, sizeof(tlsOrgConfig_t));
+        orgConfig = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_sslutils,97),1, sizeof(tlsOrgConfig_t));
         pthread_mutex_init(&orgConfig->lock, NULL);
-        orgConfig->name = ism_common_strdup(ISM_MEM_PROBE(ism_memory_utils_misc,1000),name);
+        orgConfig->name = ism_common_strdup(ISM_MEM_PROBE(ism_memory_utils_sslutils,1000),name);
         TRACE(7, "orgConfig was created for org %s: orgConfig=%p\n", name, orgConfig);
         orgConfig->useCount = 1;
         ism_common_putHashMapElement(orgConfigMap, name, 0, orgConfig, NULL);
@@ -3687,27 +3687,27 @@ int ism_ssl_setSNIConfig(const char * name, const char * serverCert, const char 
                 break;
             }
             if (serverCert) {
-                serverCert = ism_common_strdup(ISM_MEM_PROBE(ism_memory_utils_misc,1000),serverCert);
-                serverKey = ism_common_strdup(ISM_MEM_PROBE(ism_memory_utils_misc,1000),serverKey);
+                serverCert = ism_common_strdup(ISM_MEM_PROBE(ism_memory_utils_sslutils,1000),serverCert);
+                serverKey = ism_common_strdup(ISM_MEM_PROBE(ism_memory_utils_sslutils,1000),serverKey);
                 if ((serverCert == NULL) || (serverKey == NULL)) {
                     SSL_CTX_free(ctx);
                     if (serverCert)
-                        ism_common_free(ism_memory_utils_misc,(char*)serverCert);
+                        ism_common_free(ism_memory_utils_sslutils,(char*)serverCert);
                     if (serverKey)
-                        ism_common_free(ism_memory_utils_misc,(char*)serverKey);
+                        ism_common_free(ism_memory_utils_sslutils,(char*)serverKey);
                     rc = ISMRC_AllocateError;
                     ism_common_setError(rc);
                     break;
                 }
             }
             if (trustCerts && requireClientCert) {
-                trustCerts = ism_common_strdup(ISM_MEM_PROBE(ism_memory_utils_misc,1000),trustCerts);
+                trustCerts = ism_common_strdup(ISM_MEM_PROBE(ism_memory_utils_sslutils,1000),trustCerts);
                 if (trustCerts == NULL) {
                     SSL_CTX_free(ctx);
                     if (serverCert)
-                        ism_common_free(ism_memory_utils_misc,(char*)serverCert);
+                        ism_common_free(ism_memory_utils_sslutils,(char*)serverCert);
                     if (serverKey)
-                        ism_common_free(ism_memory_utils_misc,(char*)serverKey);
+                        ism_common_free(ism_memory_utils_sslutils,(char*)serverKey);
                     rc = ISMRC_AllocateError;
                     ism_common_setError(rc);
                     break;
@@ -3716,10 +3716,10 @@ int ism_ssl_setSNIConfig(const char * name, const char * serverCert, const char 
                 if (rc != ISMRC_OK) {
                     SSL_CTX_free(ctx);
                     if (serverCert)
-                        ism_common_free(ism_memory_utils_misc,(char*)serverCert);
+                        ism_common_free(ism_memory_utils_sslutils,(char*)serverCert);
                     if (serverKey)
-                        ism_common_free(ism_memory_utils_misc,(char*)serverKey);
-                    ism_common_free(ism_memory_utils_misc,(char*)trustCerts);
+                        ism_common_free(ism_memory_utils_sslutils,(char*)serverKey);
+                    ism_common_free(ism_memory_utils_sslutils,(char*)trustCerts);
                     break;
                 }
             }
@@ -3729,14 +3729,14 @@ int ism_ssl_setSNIConfig(const char * name, const char * serverCert, const char 
          * Delete the old values in the orgConfig
          */
         if (orgConfig->trustCerts) {
-            ism_common_free(ism_memory_utils_misc,orgConfig->trustCerts);
+            ism_common_free(ism_memory_utils_sslutils,orgConfig->trustCerts);
             ism_common_list_destroy(&orgConfig->trustCertsList);
             orgConfig->trustCerts = NULL;
         }
         if (orgConfig->serverCert) {
-            ism_common_free(ism_memory_utils_misc,orgConfig->serverCert);
+            ism_common_free(ism_memory_utils_sslutils,orgConfig->serverCert);
             orgConfig->serverCert = NULL;
-            ism_common_free(ism_memory_utils_misc,orgConfig->serverKey);
+            ism_common_free(ism_memory_utils_sslutils,orgConfig->serverKey);
             orgConfig->serverKey = NULL;
         }
         if (orgConfig->crlUpdateTimer) {

--- a/server_utils/src/throttle.c
+++ b/server_utils/src/throttle.c
@@ -76,7 +76,7 @@ int ism_throttle_incrementAuthFailedCount(const char * clientID) {
     ism_time_t ctime= ism_common_currentTimeNanos();
 
     if (item == NULL){
-    	throttleObj = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_misc,53),1, sizeof(ismThrottleObj));
+    	throttleObj = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_throttle,53),1, sizeof(ismThrottleObj));
     } else {
     	throttleObj = (ismThrottleObj *) item;
     }
@@ -116,7 +116,7 @@ int ism_throttle_incrementClienIDStealCount(const char * clientID) {
     ism_time_t ctime= ism_common_currentTimeNanos();
 
     if (item == NULL){
-    	throttleObj = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_misc,54),1, sizeof(ismThrottleObj));
+    	throttleObj = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_throttle,54),1, sizeof(ismThrottleObj));
     } else {
     	throttleObj = (ismThrottleObj *) item;
     }
@@ -156,7 +156,7 @@ int ism_throttle_incrementConnCloseError(const char * clientID, int rc) {
     ism_time_t ctime= ism_common_currentTimeNanos();
 
     if (item == NULL){
-    	throttleObj = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_misc,55),1, sizeof(ismThrottleObj));
+    	throttleObj = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_throttle,55),1, sizeof(ismThrottleObj));
     } else {
     	throttleObj = (ismThrottleObj *) item;
     }
@@ -214,7 +214,7 @@ int ism_throttle_termThrottle(void) {
 		ismThrottleObj * clientObj=NULL;
 		while (array[i] != ((void*)-1)) {
 			clientObj = (ismThrottleObj *)array[i]->value;
-			ism_common_free(ism_memory_utils_misc,clientObj);
+			ism_common_free(ism_memory_utils_throttle,clientObj);
 			clientObj=NULL;
 			i++;
 		}
@@ -270,7 +270,7 @@ static int delayTableCleanUpTimerTask(ism_timer_t key, ism_time_t timestamp, voi
 			//Remove from the table.
 			ism_common_removeHashMapElement(g_throttletable, dataEntries[i]->key, dataEntries[i]->key_len);
 			if(throttleObj)
-				ism_common_free(ism_memory_utils_misc,throttleObj);
+				ism_common_free(ism_memory_utils_throttle,throttleObj);
 			removedCount++;
 		}
 		i++;
@@ -334,7 +334,7 @@ int ism_throttle_removeThrottleObj(const char * clientID) {
 				rcount= throttleObj->authFailedCount;
 				stealcount= throttleObj->clientIDStealCount;
 				conncloseerr= throttleObj->connCloseErrorCount;
-				ism_common_free(ism_memory_utils_misc,throttleObj);
+				ism_common_free(ism_memory_utils_throttle,throttleObj);
 			}
 			TRACE(6, "Remove Entry from Throttle Table: ClientID=%s. FailedAuthNum=%d. StealCount=%d. ConnCloseErrorCount=%d\n", clientID, rcount, stealcount, conncloseerr);
 		}
@@ -358,7 +358,7 @@ static int removeThrottleConfiguration(void)
 	if (throttleLimitCount>0){
 		for(i=0; i<throttleLimitCount; i++){
 			ismDelay * delay =  throttleDelay[i];
-			ism_common_free(ism_memory_utils_misc,delay);
+			ism_common_free(ism_memory_utils_throttle,delay);
 		}
 		throttleLimitCount=0;
 	}
@@ -422,7 +422,7 @@ int ism_throttle_parseThrottleConfiguration(void)
 				int delayValue = ism_common_getIntConfig(delayName, 0);
 				if (delayValue>0){
 					/*If no delay value. Skip the creation of the object*/
-					ismDelay * proxyDelay = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_misc,60),1, sizeof(ismDelay));
+					ismDelay * proxyDelay = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_throttle,60),1, sizeof(ismDelay));
 					proxyDelay->delay_time = delayValue;
 					proxyDelay->delay_in_nanos = delayValue * MILLION;
 					proxyDelay->limit = limitvalue;
@@ -439,9 +439,9 @@ int ism_throttle_parseThrottleConfiguration(void)
 			}else if(proplen == THROTTLE_CONNCLOSEERROR_LIMIT_STR_SIZE && strncasecmp(THROTTLE_CONNCLOSEERROR_LIMIT_STR,propName, THROTTLE_CONNCLOSEERROR_LIMIT_STR_SIZE)==0 ){
 
 				if(throttleConnCloseErrorDelay!=NULL)
-					ism_common_free(ism_memory_utils_misc,throttleConnCloseErrorDelay);
+					ism_common_free(ism_memory_utils_throttle,throttleConnCloseErrorDelay);
 
-				throttleConnCloseErrorDelay =  ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_misc,62),1, sizeof(ismDelay));
+				throttleConnCloseErrorDelay =  ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_throttle,62),1, sizeof(ismDelay));
 
 				int limitvalue = ism_common_getIntProperty(props, propName,0);
 				int delayValue = ism_common_getIntConfig(THROTTLE_CONNCLOSEERROR_DELAY_STR, 0);
@@ -732,7 +732,7 @@ int ism_throttle_setEnabled(int enabled) {
             //Remove from the table.
             ism_common_removeHashMapElement(g_throttletable, array[i]->key, array[i]->key_len);
             if(clientObj)
-                ism_common_free(ism_memory_utils_misc,clientObj);
+                ism_common_free(ism_memory_utils_throttle,clientObj);
             clientObj=NULL;
             i++;
         }

--- a/server_utils/src/xmlparser.c
+++ b/server_utils/src/xmlparser.c
@@ -236,7 +236,7 @@ static void * domAlloc(xdom * dom, int size) {
      * If the current chunk is not big enough, allocate a new one
      */
     if (dom->DomLeft < (size+pad)) {
-        char * newdom = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_misc,3),DOM_ALLOC);
+        char * newdom = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_xml,3),DOM_ALLOC);
         if (!newdom) {
             fatalerror(dom, 5, "05", "Unable to allocate memory.", NULL);
             return NULL;
@@ -661,7 +661,7 @@ static int isEquals(int ch) {
  * xml object constructor
  */
 xdom * ism_xml_new(char * systemId) {
-    xdom * dom = (xdom *) ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_misc,4),DOM_ALLOC);
+    xdom * dom = (xdom *) ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_xml,4),DOM_ALLOC);
 
     if (!dom) {
         return NULL;
@@ -677,7 +677,7 @@ xdom * ism_xml_new(char * systemId) {
         strcpy(dom->SIDBuf, systemId);
         dom->SystemId = dom->SIDBuf;
     } else {
-        dom->SystemId = ism_common_strdup(ISM_MEM_PROBE(ism_memory_utils_misc,1000),systemId);
+        dom->SystemId = ism_common_strdup(ISM_MEM_PROBE(ism_memory_utils_xml,1000),systemId);
     }
     dom->logx = &logcallx;
     dom->Line = 1;
@@ -736,15 +736,15 @@ void ism_xml_setSystemId(xdom * dom, const char * systemId, int line, int fileno
         fileno = 255;
     if (systemId) {
         if (!dom->fileNames) {
-            dom->fileNames = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_misc,5),sizeof(char *), 512);
+            dom->fileNames = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_xml,5),sizeof(char *), 512);
             // SA_ASSUME(dom->fileNames != NULL);
-            dom->fileNames[0] = ism_common_strdup(ISM_MEM_PROBE(ism_memory_utils_misc,1000),dom->SystemId ? dom->SystemId : "");
+            dom->fileNames[0] = ism_common_strdup(ISM_MEM_PROBE(ism_memory_utils_xml,1000),dom->SystemId ? dom->SystemId : "");
         }
         if (!dom->fileNames[fileno])
-            dom->fileNames[fileno] = ism_common_strdup(ISM_MEM_PROBE(ism_memory_utils_misc,1000),systemId);
+            dom->fileNames[fileno] = ism_common_strdup(ISM_MEM_PROBE(ism_memory_utils_xml,1000),systemId);
         if (!strcmp(dom->fileNames[fileno], systemId)) {
-            ism_common_free(ism_memory_utils_misc,dom->fileNames[fileno]);
-            dom->fileNames[fileno] = ism_common_strdup(ISM_MEM_PROBE(ism_memory_utils_misc,1000),systemId);
+            ism_common_free(ism_memory_utils_xml,dom->fileNames[fileno]);
+            dom->fileNames[fileno] = ism_common_strdup(ISM_MEM_PROBE(ism_memory_utils_xml,1000),systemId);
         }
     }
     if (line >= 0)
@@ -775,29 +775,29 @@ void ism_xml_free(xdom * dom) {
     char * nd;
     while (d) {
         nd  = *(char * *)d;
-        ism_common_free(ism_memory_utils_misc,d);
+        ism_common_free(ism_memory_utils_xml,d);
         d = nd;
     }
     dom->DomChunk = 0;
     if (dom->copybuf) {
-        ism_common_free(ism_memory_utils_misc,dom->copybuf);
+        ism_common_free(ism_memory_utils_xml,dom->copybuf);
         dom->copybuf = NULL;
     }
     if (dom->SystemId && dom->SystemId != dom->SIDBuf) {
-        ism_common_free(ism_memory_utils_misc,dom->SystemId);
+        ism_common_free(ism_memory_utils_xml,dom->SystemId);
         dom->SystemId = NULL;
     }
     if (dom->fileNames) {
         for (i=0; i<512; i++) {
             if (dom->fileNames[i]) {
-                ism_common_free(ism_memory_utils_misc,dom->fileNames[i]);
+                ism_common_free(ism_memory_utils_xml,dom->fileNames[i]);
                 dom->fileNames[i] = NULL;
             }
         }
-        ism_common_free(ism_memory_utils_misc,dom->fileNames);
+        ism_common_free(ism_memory_utils_xml,dom->fileNames);
         dom->fileNames = NULL;
     }
-    ism_common_free(ism_memory_utils_misc,dom);
+    ism_common_free(ism_memory_utils_xml,dom);
 }
 
 
@@ -818,7 +818,7 @@ int ism_xml_include(xdom * dom, char * name, int fileno) {
     }
     fseek(f, 0, SEEK_END);
     len = ftell(f);
-    buf = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_misc,13),len+2);
+    buf = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_xml,13),len+2);
     if (!buf) {
         warnerror(dom, "22", "Unable to allocate memory.", NULL);
         fclose(f);
@@ -830,7 +830,7 @@ int ism_xml_include(xdom * dom, char * name, int fileno) {
     buf[bread+1] = 0;                                        /* Double null*/
     if (bread != len) {
         warnerror(dom, "23", "Unable to read file: ", name);
-        ism_common_free(ism_memory_utils_misc,buf);
+        ism_common_free(ism_memory_utils_xml,buf);
         fclose(f);
         return -3;
     }
@@ -839,7 +839,7 @@ int ism_xml_include(xdom * dom, char * name, int fileno) {
     /*
      *
      */
-    savesysid = ism_common_strdup(ISM_MEM_PROBE(ism_memory_utils_misc,1000),ism_xml_getSystemId(dom));
+    savesysid = ism_common_strdup(ISM_MEM_PROBE(ism_memory_utils_xml,1000),ism_xml_getSystemId(dom));
     saveline  = ism_xml_getLine(dom);
     savefileno = ism_xml_getFileno(dom);
     ism_xml_setSystemId(dom, name, 1, fileno);
@@ -848,7 +848,7 @@ int ism_xml_include(xdom * dom, char * name, int fileno) {
     }
     rc = ism_xml_parse(dom, buf, len, 0);
     ism_xml_setSystemId(dom, savesysid, saveline, savefileno);
-    ism_common_free(ism_memory_utils_misc,savesysid);
+    ism_common_free(ism_memory_utils_xml,savesysid);
     return rc;
 }
 
@@ -932,7 +932,7 @@ int ism_xml_parse (xdom * dom, char * buf, int len, int copy) {
      * Copy buffer if requested
      */
     if (copy) {
-        dom->copybuf = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_misc,16),len+1);
+        dom->copybuf = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_xml,16),len+1);
         // SA_ASSUME(dom->copybuf != NULL);
         memcpy(dom->copybuf, buf, len);
         buf = dom->copybuf;
@@ -1092,7 +1092,7 @@ int ism_xml_parse_stream(xdom * dom, ism_xml_getch_t get_ch, void * parm) {
     int  ch, prevch;
     int  mode;
     char * tag = NULL;
-    char * buf = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_misc,17),32700);
+    char * buf = ism_common_malloc(ISM_MEM_PROBE(ism_memory_utils_xml,17),32700);
     char * bufend = buf+32700;
     char * start = NULL;
     char * bufp;
@@ -1105,7 +1105,7 @@ int ism_xml_parse_stream(xdom * dom, ism_xml_getch_t get_ch, void * parm) {
         rc = setjmp(dom->env);
         if (rc) {
             dom->jmpset = 0;
-            ism_common_free(ism_memory_utils_misc,buf);
+            ism_common_free(ism_memory_utils_xml,buf);
             return rc;
         }
         savewarnings = 0;
@@ -1772,7 +1772,7 @@ XAPI void *  ism_xml_getuserdata(xdom * dom) {
  */
 XAPI xdompos_t * ism_xml_saveposition(xdom * dom, xdompos_t * dompos) {
     if (!dompos)
-        dompos = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_misc,19),1, sizeof(xdompos_t));
+        dompos = ism_common_calloc(ISM_MEM_PROBE(ism_memory_utils_xml,19),1, sizeof(xdompos_t));
     // SA_ASSUME(dompos != NULL);
     memcpy(dompos, dom, sizeof(xdompos_t));
     dompos->dom = dom;
@@ -1808,7 +1808,7 @@ XAPI xnode_t * ism_xml_node(xdom * dom) {
  * xml free a dom position object.
  */
 XAPI void ism_xml_freeposition(xdompos_t * dompos) {
-    ism_common_free(ism_memory_utils_misc,dompos);
+    ism_common_free(ism_memory_utils_xml,dompos);
 }
 
 


### PR DESCRIPTION
This change adds more categories of memory that we allocate from and track (at the moment there is a large server_utils_misc category) and this will help us figure out what Amlen is using memory for,