### PR TITLE
adapt to kafka leadership changes more smoothly

### DIFF
--- a/server_proxy/src/pxmhub.c
+++ b/server_proxy/src/pxmhub.c
@@ -3872,17 +3872,16 @@ xUNUSED static int mhubDataRetryConnect(ism_timer_t key, ism_time_t now, void * 
 
     if(!g_shuttingDown){
     	transport->ready = 7;  //Set ready for Connect Timeout. See ddosTimer
-		int rc = ism_kafka_createConnection(transport, pobj->server);
-		if(rc){
-
-			char * erbuf = alloca(2048);
-			ism_common_formatLastError(erbuf, 2048);
-			LOG(ERROR, Server, 987, "%u%s%s%u%d%d%d%s",  "Failed to create the mhub data connection: connect={0} name={1} server_addr={2} server_port={3} partition={4} nodeid={5} rc={6} errmsg={7}",
-					    			transport->index, transport->name, transport->server_addr, transport->serverport, pobj->partID, pobj->nodeID, rc, erbuf);
-			transport->close(transport, rc, 0,  erbuf);
-		}
+    	int rc = ism_kafka_createConnection(transport, pobj->server);
+    	if(rc){
+    		char * erbuf = alloca(2048);
+    		ism_common_formatLastError(erbuf, 2048);
+    		LOG(ERROR, Server, 987, "%u%s%s%u%d%d%d%s",  "Failed to create the mhub data connection: connect={0} name={1} server_addr={2} server_port={3} partition={4} nodeid={5} rc={6} errmsg={7}",
+			    			transport->index, transport->name, transport->server_addr, transport->serverport, pobj->partID, pobj->nodeID, rc, erbuf);
+    		transport->close(transport, rc, 0,  erbuf);
+    	}
     } else {
-    		TRACE(5, "Failed to connect. Msproxy is shutting down. name=%s\n", transport->clientID);
+    	TRACE(5, "Failed to connect. Msproxy is shutting down. name=%s\n", transport->clientID);
     }
     return 0;
 }

--- a/server_proxy/src/pxmhub.c
+++ b/server_proxy/src/pxmhub.c
@@ -999,7 +999,7 @@ static mhub_topic_t * changePartitions(ism_mhub_t * mhub, mhub_topic_t * mtopic,
     if (partcount < mtopic->partcount) {
         for (i = partcount; i < mtopic->partcount; i++) {
             mhub_part_t * part = mtopic->partitions+i;
-        	pthread_mutex_lock(&part->lock);
+            pthread_mutex_lock(&part->lock);
             if (part->transport) {
                 ism_transport_t * transport = part->transport;
                 pthread_mutex_unlock(&part->lock);
@@ -3327,7 +3327,9 @@ static int processPartMetadata(ism_mhub_t * mhub, mhub_broker_list_t * brokers, 
             	    									mhub->id, topicname, partid, partrc, leader, part->leader);
             	if(part->transport){
             		ism_transport_t * transport = part->transport;
+            		pthread_mutex_unlock(&part->lock);
             		transport->close(transport, ISMRC_EndpointDisabled, 0, "Change in partition leader");
+            		pthread_mutex_lock(&part->lock);
             		needDataConn=1;
             	}
 


### PR DESCRIPTION
When the metadata connection to kafka is broken, currently (in some cases) it does not recover and reestablish the connection successfully