### PR TITLE
dont wait for replicasReady to be defined in recovery code

### DIFF
--- a/operator/roles/amlen/tasks/create_pair.yml
+++ b/operator/roles/amlen/tasks/create_pair.yml
@@ -193,11 +193,9 @@
         namespace: "{{ _amlen_namespace }}"
       register: statefulset
       until:
-      - statefulset.resources[0].status.readyReplicas is defined
+      - statefulset.resources[0].status.replicas is defined
       retries: 10
       delay: 10
-
-
 
     - fail:
         msg: "statefulset contains 2 pods manual recovery needed"


### PR DESCRIPTION
If a statefulset is deleted the replicasready field is not defined until at least one pod is ready. We need the recovery code to kick in before then so just wait till the replicas field is defined so we know how many it should have.