### PR TITLE
[patch] fix memory leak in hashing admin user password

### DIFF
--- a/server_utils/include/ismutil.h
+++ b/server_utils/include/ismutil.h
@@ -4050,6 +4050,7 @@ uint64_t ism_common_get_ffdc_count(void);
 #define ismCommonFFDCPROBE_047 47
 #define ismCommonFFDCPROBE_048 48
 #define ismCommonFFDCPROBE_049 49
+#define ismCommonFFDCPROBE_050 50
 
 
 /*----- start stuff for processing structure identifiers -----*/

--- a/server_utils/include/sasl_scram.h
+++ b/server_utils/include/sasl_scram.h
@@ -128,6 +128,13 @@ int ism_sasl_scram_salt_password (ism_sasl_scram_context * context, const char *
                         int iteration, concat_alloc_t * outbuf) ;
 
 /**
+ * Salting the password - alternative when we don't have a ism_sasl_scram_context
+ */
+int ism_sasl_scram_mechanism_salt_password (ism_sasl_machanism_e mechanism, const char *in, int in_size,
+                        const char *salt, int salt_size,
+                        int iteration, concat_alloc_t * outbuf) ;
+
+/**
  * Perform keyed-hash message authentication
  *
  * NOTE: OpenSSL HMAC will be used.


### PR DESCRIPTION
We were leaking memory when we hashed a password when authenticating an admin request. The area has been reworked slightly to avoid allocating the memory in the first place.