### PR TITLE
For main always use default distro and build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
         stage("Pre") {
             when {
               not {
-                branch 'ib.branches'
+                branch 'main'
               }
             }
             agent any 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,11 @@ pipeline {
 
   stages {
         stage("Pre") {
+            when {
+              not {
+                branch 'main'
+              }
+            }
             agent any 
             steps {
                 script {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
         stage("Pre") {
             when {
               not {
-                branch 'main'
+                branch 'ib.branches'
               }
             }
             agent any 


### PR DESCRIPTION
If a merge into main has squashed multiple commits that were running non standard builds into the comment then the build could end up doing anything so for builds of main ignore them and just use the defaults.