### PR TITLE
[patch] Cope with java not being in path during post-install by guessing java path

### DIFF
--- a/server_build/build_pkg.sh
+++ b/server_build/build_pkg.sh
@@ -982,6 +982,7 @@ case $BUILD_MODE in
     default_rpms)         bld_default_rpms;;
     serverplus_rpm)       bld_serverplus_rpm;;
     server_rpm)           bld_imaserverplain_rpm;;
+    webui_rpm)            bld_imagui_rpm;;
     prep_server)          prep_server;;
     prep_mqcbridge)       prep_mqcbridge;;
     prep_protocolplugin)  prep_protocolplugin;;

--- a/server_build/docker_build/imawebui.spec
+++ b/server_build/docker_build/imawebui.spec
@@ -24,8 +24,9 @@ AutoReqProv: no
 Group: Applications/Communications
 Source: %{name}.tar.gz
 BuildRoot: %{_topdir}/tmp/%{name}-%{Version}.${Release}
-#NB: If the java version is changed from 1.8.0 below, the postInstallWebUI (which in edge cases guesses a java path) needs to be updated
-Requires: net-tools, openldap, openldap-servers, openldap-clients, tar, openssl, procps, java-1.8.0-openjdk-headless, which
+Requires: net-tools, openldap, openldap-servers, openldap-clients, tar, openssl, procps, which
+#NB: If the java version is changed from 1.8.0 below, the postInstallWebUI.sh (which in edge cases guesses a java path) needs to be updated
+Requires(post): java-1.8.0-openjdk-headless
 Obsoletes: IBMIoTMessageSightWebUI
 
 %description

--- a/server_build/docker_build/imawebui.spec
+++ b/server_build/docker_build/imawebui.spec
@@ -24,6 +24,7 @@ AutoReqProv: no
 Group: Applications/Communications
 Source: %{name}.tar.gz
 BuildRoot: %{_topdir}/tmp/%{name}-%{Version}.${Release}
+#NB: If the java version is changed from 1.8.0 below, the postInstallWebUI (which in edge cases guesses a java path) needs to be updated
 Requires: net-tools, openldap, openldap-servers, openldap-clients, tar, openssl, procps, java-1.8.0-openjdk-headless, which
 Obsoletes: IBMIoTMessageSightWebUI
 

--- a/server_gui/scripts/createAcct.sh
+++ b/server_gui/scripts/createAcct.sh
@@ -41,3 +41,4 @@ if [[ $# -lt 3 ]]; then
 fi
 
 echo >> "${LOG}"
+exit 0

--- a/server_gui/scripts/postInstallWebUI.sh
+++ b/server_gui/scripts/postInstallWebUI.sh
@@ -535,18 +535,18 @@ function update_liberty_ldap_password() {
                 numtries=$((numtries + 1))
                 echo "Updating liberty: failed encoding of password - will retry" >> ${INSTALL_LOG}
                 echo "Current java status diagnostics"  >> ${INSTALL_LOG}
-                which java 2>&1 >> ${INSTALL_LOG}
-                ls -l /usr/bin/java 2>&1 >> ${INSTALL_LOG}
-                ls -l /etc/alternatives/java 2>&1 >> ${INSTALL_LOG}
-                ls -l /usr/lib/jvm  2>&1 >> ${INSTALL_LOG}
-                ls -l /usr/lib/jvm/java-1.8.0-openjd*/jre/bin 2>&1 >> ${INSTALL_LOG}
-                ls -l /usr/lib/jvm/java-1.8.0-openjd*/jre 2>&1 >> ${INSTALL_LOG}
-                echo $PATH 2>&1  >> ${INSTALL_LOG}
-                ${WLPINSTALLDIR}/bin/securityUtility encode --encoding=aes ${PASSWD} 2>&1 >> ${INSTALL_LOG}
+                which java >> ${INSTALL_LOG} 2>&1 
+                ls -l /usr/bin/java >> ${INSTALL_LOG} 2>&1
+                ls -l /etc/alternatives/java >> ${INSTALL_LOG} 2>&1
+                ls -l /usr/lib/jvm >> ${INSTALL_LOG} 2>&1 
+                ls -l /usr/lib/jvm/java-1.8.0-openjd*/jre/bin >> ${INSTALL_LOG} 2>&1 
+                ls -l /usr/lib/jvm/java-1.8.0-openjd*/jre >> ${INSTALL_LOG} 2>&1 
+                echo $PATH >> ${INSTALL_LOG} 2>&1 
+                ${WLPINSTALLDIR}/bin/securityUtility encode --encoding=aes ${PASSWD} >> ${INSTALL_LOG} 2>&1 
 
                 if [ ! -x "$(command -v java)" ]; then
                     if [ -z "${JAVA_HOME}" ]; then
-                        #We currently prereq java 1.8 so this should exist - if the rpm spec changes, update our guess below
+                        #We currently prereq java 1.8 so this should exist - if the rpm spec changes, update our guess (3 occurences) below
                         
                         unset -v latestjava
                         unset -v chosenjava
@@ -578,7 +578,7 @@ function update_liberty_ldap_password() {
                 fi
             else
                 echo "Updating liberty: don't have encoded password - after multiple retries" >> ${INSTALL_LOG}
-                echo "$(ls -l ${WLPINSTALLDIR}/bin/securityUtility)" >> ${INSTALL_LOG}
+                echo "$(ls -l ${WLPINSTALLDIR}/bin/securityUtility)" >> ${INSTALL_LOG} 2>&1
                 exit 1
             fi
         fi
@@ -661,7 +661,7 @@ if [ ! -f "${LDAPDIR}"/.accountsCreated ]; then
     fi
     update_liberty_ldap_password
 
-    ${WEBUIBINDIR}/createAcct.sh "${LDAPDIR}/.key" 2>&1 >> "${LOGDIR}/createAcct.log"
+    ${WEBUIBINDIR}/createAcct.sh "${LDAPDIR}/.key" >> "${LOGDIR}/createAcct.log" 2>&1
 
     if [ "$?" -eq "0" ]; then
         touch "${LDAPDIR}"/.accountsCreated

--- a/server_gui/scripts/postInstallWebUI.sh
+++ b/server_gui/scripts/postInstallWebUI.sh
@@ -508,21 +508,23 @@ function update_liberty_ldap_password() {
 
     sed -i 's#keystore_imakey" value=.*#keystore_imakey" value="'"${PWDBASE64}"'" />#' "${WLPDIR}"/usr/servers/ISMWebUI/properties.xml
     echo "Updated LDAP password in ${WLPDIR}/usr/servers/ISMWebUI/properties.xml." >> ${INSTALL_LOG}
-    
-    lval=$(${WLPINSTALLDIR}/bin/securityUtility encode --encoding=aes $(cat ${LDAPDIR}/.key))
 
-    if [ -z "$lval" ]; then
-        echo "Updating liberty: don't have encoded password." >> ${INSTALL_LOG}
+    PASSWD=$(cat ${LDAPDIR}/.key)
+
+    if [ -z "$PASSWD" ]; then
+        echo "Updating liberty: don't have key file" >> ${INSTALL_LOG}
         exit 1
     fi
 
-    echo "Before updating ldap.xml" >> ${INSTALL_LOG}
-    md5sum "${WLPDIR}/usr/servers/ISMWebUI/ldap.xml" >> ${INSTALL_LOG}
+    lval=$(${WLPINSTALLDIR}/bin/securityUtility encode --encoding=aes ${PASSWD})
+
+    if [ -z "$lval" ]; then
+        echo "Updating liberty: don't have encoded password." >> ${INSTALL_LOG}
+        echo "$(ls -l ${WLPINSTALLDIR}/bin/securityUtility)" >> ${INSTALL_LOG}
+        exit 1
+    fi
+
     sed -i 's#bindPassword=.*#bindPassword="'"${lval}"'"#' "${WLPDIR}"/usr/servers/ISMWebUI/ldap.xml 2>&1 >> ${INSTALL_LOG}
-
-    echo "After updating ldap.xml" >> ${INSTALL_LOG}
-    md5sum "${WLPDIR}/usr/servers/ISMWebUI/ldap.xml" >> ${INSTALL_LOG}
-
     echo "Updated LDAP password in ${WLPDIR}/usr/servers/ISMWebUI/ldap.xml." >> ${INSTALL_LOG}
 }
 

--- a/server_gui/scripts/postInstallWebUI.sh
+++ b/server_gui/scripts/postInstallWebUI.sh
@@ -541,6 +541,8 @@ function update_liberty_ldap_password() {
                 ls -l /usr/lib/jvm/java-1.8.0-openjd*/jre >> ${INSTALL_LOG}
                 echo $PATH  >> ${INSTALL_LOG}
                 ${WLPINSTALLDIR}/bin/securityUtility encode --encoding=aes ${PASSWD} 2>&1 >> ${INSTALL_LOG}
+                #clear path cache:
+                hash -r >> ${INSTALL_LOG}
             else
                 echo "Updating liberty: don't have encoded password - after many retries" >> ${INSTALL_LOG}
                 echo "$(ls -l ${WLPINSTALLDIR}/bin/securityUtility)" >> ${INSTALL_LOG}

--- a/server_gui/scripts/postInstallWebUI.sh
+++ b/server_gui/scripts/postInstallWebUI.sh
@@ -509,7 +509,13 @@ function update_liberty_ldap_password() {
     echo "Updated LDAP password in ${WLPDIR}/usr/servers/ISMWebUI/properties.xml." >> ${INSTALL_LOG}
     
     lval=$(${WLPINSTALLDIR}/bin/securityUtility encode --encoding=aes $(cat ${LDAPDIR}/.key))
-    sed -i 's#bindPassword=.*#bindPassword="'"${lval}"'"#' "${WLPDIR}"/usr/servers/ISMWebUI/ldap.xml
+
+    echo "Before updating ldap.xml" >> ${INSTALL_LOG}
+    md5sum "${WLPDIR}"/usr/servers/ISMWebUI/ldap.xml" >> ${INSTALL_LOG}
+    sed -i 's#bindPassword=.*#bindPassword="'"${lval}"'"#' "${WLPDIR}"/usr/servers/ISMWebUI/ldap.xml 2>&1 >> ${INSTALL_LOG}
+
+    echo "After updating ldap.xml" >> ${INSTALL_LOG}
+    md5sum "${WLPDIR}"/usr/servers/ISMWebUI/ldap.xml" >> ${INSTALL_LOG}
 
     echo "Updated LDAP password in ${WLPDIR}/usr/servers/ISMWebUI/ldap.xml." >> ${INSTALL_LOG}
 }
@@ -586,9 +592,10 @@ if [ ! -f "${LDAPDIR}"/.accountsCreated ]; then
     fi
     update_liberty_ldap_password
 
-    if ${WEBUIBINDIR}/createAcct.sh "${LDAPDIR}/.key" >> "${LOGDIR}/createAcct.log" 2>&1 ; then
+    ${WEBUIBINDIR}/createAcct.sh "${LDAPDIR}/.key" 2>&1 >> "${LOGDIR}/createAcct.log"
+
+    if [ "$?" -eq "0" ]; then
         touch "${LDAPDIR}"/.accountsCreated
-        echo "There was an issue creating accounts for imawebui. See the ${LOGDIR}/createAcct.log" >> ${INSTALL_LOG}
 
         if [ -f "${LDAPDIR}"/.configuredOpenLDAP ]; then
             slapdpid=$(check_openldap_server)

--- a/server_gui/scripts/postInstallWebUI.sh
+++ b/server_gui/scripts/postInstallWebUI.sh
@@ -505,17 +505,23 @@ function generate_openldap_password() {
 }
 
 function update_liberty_ldap_password() {
+
     sed -i 's#keystore_imakey" value=.*#keystore_imakey" value="'"${PWDBASE64}"'" />#' "${WLPDIR}"/usr/servers/ISMWebUI/properties.xml
     echo "Updated LDAP password in ${WLPDIR}/usr/servers/ISMWebUI/properties.xml." >> ${INSTALL_LOG}
     
     lval=$(${WLPINSTALLDIR}/bin/securityUtility encode --encoding=aes $(cat ${LDAPDIR}/.key))
 
+    if [ -z "$lval" ]; then
+        echo "Updating liberty: don't have encoded password." >> ${INSTALL_LOG}
+        exit 1
+    fi
+
     echo "Before updating ldap.xml" >> ${INSTALL_LOG}
-    md5sum "${WLPDIR}"/usr/servers/ISMWebUI/ldap.xml" >> ${INSTALL_LOG}
+    md5sum "${WLPDIR}/usr/servers/ISMWebUI/ldap.xml" >> ${INSTALL_LOG}
     sed -i 's#bindPassword=.*#bindPassword="'"${lval}"'"#' "${WLPDIR}"/usr/servers/ISMWebUI/ldap.xml 2>&1 >> ${INSTALL_LOG}
 
     echo "After updating ldap.xml" >> ${INSTALL_LOG}
-    md5sum "${WLPDIR}"/usr/servers/ISMWebUI/ldap.xml" >> ${INSTALL_LOG}
+    md5sum "${WLPDIR}/usr/servers/ISMWebUI/ldap.xml" >> ${INSTALL_LOG}
 
     echo "Updated LDAP password in ${WLPDIR}/usr/servers/ISMWebUI/ldap.xml." >> ${INSTALL_LOG}
 }

--- a/server_gui/scripts/postInstallWebUI.sh
+++ b/server_gui/scripts/postInstallWebUI.sh
@@ -533,6 +533,14 @@ function update_liberty_ldap_password() {
             if [ "$numtries" -lt 10 ]; then
                 numtries=$((numtries + 1))
                 echo "Updating liberty: failed encoding of password - will retry" >> ${INSTALL_LOG}
+                echo "Current java status diagnostics"  >> ${INSTALL_LOG}
+                which java >> ${INSTALL_LOG}
+                ls -l /usr/bin/java >> ${INSTALL_LOG}
+                ls -l /etc/alternatives/java >> ${INSTALL_LOG}
+                ls -l /usr/lib/jvm/java-1.8.0-openjd*/jre/bin >> ${INSTALL_LOG}
+                ls -l /usr/lib/jvm/java-1.8.0-openjd*/jre >> ${INSTALL_LOG}
+                echo $PATH  >> ${INSTALL_LOG}
+                ${WLPINSTALLDIR}/bin/securityUtility encode --encoding=aes ${PASSWD} 2>&1 >> ${INSTALL_LOG}
             else
                 echo "Updating liberty: don't have encoded password - after many retries" >> ${INSTALL_LOG}
                 echo "$(ls -l ${WLPINSTALLDIR}/bin/securityUtility)" >> ${INSTALL_LOG}


### PR DESCRIPTION
This is a bit hacky. 
If there is no JVM on the system and a JVM and amlen-webui are installed in the same rpm transaction, then on RHEL8 systems, that JVM is often not the default JVM for the system (i.e. /usr/bin/java is not a symlink to it) during the post install phase of the transaction.

I /think/ this is a bug in the rpm at this vintage - but we would around it by - if no java is in the path when we wanting to use it - dumping to our log some interesting directories and then explicitly setting a path to the JVM we have pre-reqd.