### PR TITLE
[patch] node is overriding variant and sequence number in uuids

### DIFF
--- a/server_utils/src/ismutil.c
+++ b/server_utils/src/ismutil.c
@@ -4096,7 +4096,7 @@ const char * ism_common_newUUID(char * buf, int len, int type, ism_time_t time) 
         uuid[1] = (uint32_t)(utime>>16) & 0xffff0000;
         uuid[1] |= (((uint32_t)(utime>>48)) & 0x0fff);
         uuid[1] |= 0x00001000;    /* Set version */
-        uuid[2] = ((seq<<16)&0x3FFF0000) | (uint32_t)(node>>32);
+        uuid[2] = ((seq<<16)&0x3FFF0000) | (((uint32_t)(node>>32))&0x0000FFFF);
         uuid[2] |= 0x80000000;    /* Set variation */
         uuid[3] = (uint32_t)node;
     } else if (type == 4) {


### PR DESCRIPTION
https://www.uuidtools.com/uuid-versions-explained Explains that a type 1 uuid is of the form

LLLLLLLL-MMMM-VHHH-RSSS-NNNNNNNNNNNN
Where:
L  = Low Time
M =  Mid Time
V = Version (1)
H = High Time
R = Variant (in range 8-b inclusive as is starts 0b10......)
S = Sequence number
N = Node

*NB* Each Letter is a nibble (hex digit) not a byte

With the code as it stands in the high bits of the node are set, it is or'd in with the bytes that are used for the RSSS - i.e. corrupting the sequence number or even the variant.

This is a tiny fix that ensures the 4 nibbles (two bytes) that are reserved for the sequence number+variant are not or'd with the node.