### PR TITLE
[patch] Fix SourceQoS setting in kafka bridge

### DIFF
--- a/server_proxy_br/src/bridge.c
+++ b/server_proxy_br/src/bridge.c
@@ -1095,7 +1095,7 @@ static int doSubscribe(ism_transport_t * transport, ism_forwarder_t * forwarder)
     int qos = forwarder->subQoS;
     if (forwarder->evst_dest && qos > 1)
         qos = 1;                       /* QoS=2 not supported for Event Streams destination */
-    if (transport->pobj->maxqos > qos)
+    if (transport->pobj->maxqos < qos)
         qos = transport->pobj->maxqos; /* QoS cannot be greater than allowd by the source server */
 
     forwarder->subcount = 0;


### PR DESCRIPTION
There is a setting that allows the maximum qos the imabridge uses when it makes a subscription to be controlled. Currently this setting is broken and the bridge always subscribes with maxqos=2.

This is a 1-character change that makes the sourceqos setting in the bridge work.