### PR TITLE
Updates to the operator

### DIFF
--- a/operator/config/default/manager_auth_proxy_patch.yaml
+++ b/operator/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy@sha256:0df4ae70e3bd0feffcec8f5cdb428f4abe666b667af991269ec5cb0bbda65869
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/operator/config/manifests/bases/eclipse-amlen-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/eclipse-amlen-operator.clusterserviceversion.yaml
@@ -200,7 +200,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=0
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+                image: gcr.io/kubebuilder/kube-rbac-proxy@sha256:0df4ae70e3bd0feffcec8f5cdb428f4abe666b667af991269ec5cb0bbda65869
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443

--- a/operator/config/manifests/bases/eclipse-amlen-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/eclipse-amlen-operator.clusterserviceversion.yaml
@@ -221,6 +221,10 @@ spec:
                 env:
                 - name: ANSIBLE_GATHERING
                   value: explicit
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
                 image: quay.io/amlen/operator:v1.0.3-a
                 livenessProbe:
                   httpGet:
@@ -238,7 +242,7 @@ spec:
                 resources:
                   limits:
                     cpu: 500m
-                    memory: 768Mi
+                    memory: 1500Mi
                   requests:
                     cpu: 10m
                     memory: 256Mi


### PR DESCRIPTION
We were not setting the WATCH_NAMESPACES environment variable which means even when installing in namepsace scope it was effectivly running at cluster level. Also increasing memory as we've seen cases where the default wasn't enough.