### PR TITLE
Move operator to 1.0.4a

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.0.3-a
+VERSION ?= 1.0.3
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.0.3
+VERSION ?= 1.0.4-a
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -36,6 +36,10 @@ spec:
         env:
         - name: ANSIBLE_GATHERING
           value: explicit
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['olm.targetNamespaces']
         securityContext:
           allowPrivilegeEscalation: false
         livenessProbe:
@@ -55,7 +59,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 768Mi
+            memory: 1500Mi
           requests:
             cpu: 10m
             memory: 256Mi

--- a/operator/config/manifests/bases/eclipse-amlen-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/eclipse-amlen-operator.clusterserviceversion.yaml
@@ -32,13 +32,13 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Streaming & Messaging
-    containerImage: quay.io/amlen/operator:v1.0.3-a
+    containerImage: quay.io/amlen/operator:v1.0.3
     createdAt: "2022-11-24T15:31:00Z"
     description: An operator to run the Eclipse Amlen MQTT Broker
     operators.operatorframework.io/builder: operator-sdk-v1.25.2
     operators.operatorframework.io/project_layout: ansible.sdk.operatorframework.io/v1
     repository: https://github.com/eclipse/amlen
-  name: eclipse-amlen-operator.v1.0.3-a
+  name: eclipse-amlen-operator.v1.0.3
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -225,7 +225,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/amlen/operator:v1.0.3-a
+                image: quay.io/amlen/operator:v1.0.3
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -310,4 +310,4 @@ spec:
   provider:
     name: Eclipse Amlen
     url: https://eclipse.org/amlen
-  version: 1.0.3-a
+  version: 1.0.3

--- a/operator/config/manifests/bases/eclipse-amlen-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/eclipse-amlen-operator.clusterserviceversion.yaml
@@ -32,13 +32,13 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Streaming & Messaging
-    containerImage: quay.io/amlen/operator:v1.0.3
+    containerImage: quay.io/amlen/operator:v1.0.4-a
     createdAt: "2022-11-24T15:31:00Z"
     description: An operator to run the Eclipse Amlen MQTT Broker
     operators.operatorframework.io/builder: operator-sdk-v1.25.2
     operators.operatorframework.io/project_layout: ansible.sdk.operatorframework.io/v1
     repository: https://github.com/eclipse/amlen
-  name: eclipse-amlen-operator.v1.0.3
+  name: eclipse-amlen-operator.v1.0.4-a
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -225,7 +225,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/amlen/operator:v1.0.3
+                image: quay.io/amlen/operator:v1.0.4-a
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -310,4 +310,4 @@ spec:
   provider:
     name: Eclipse Amlen
     url: https://eclipse.org/amlen
-  version: 1.0.3
+  version: 1.0.4-a

--- a/operator/roles/amlen/tasks/main.yml
+++ b/operator/roles/amlen/tasks/main.yml
@@ -53,7 +53,7 @@
       conditions:
         - type: Ready
           status: "True"
-          message: "Amlen not ready"
+          message: "Amlen Ready"
           reason: "Ready"
   when:
     - operator_pause is not defined or not operator_pause


### PR DESCRIPTION
From readme:

> The release process is currently a bit awkward what needs to happen is:
> 
> push a change that moves the version from the current alpha version to the actual version, ie if the version is 1.0.3-a then submit a PR to change it to version 1.0.3
> 
> When that has merged into main and completed the build:
> 
>     Tag the operator-bundle:main-d as version-pre eg 1.0.3-pre
>     Tag the operator:main as v1.0.3
> 
> Push a change that moves the version in main to the next alpha channel eg 1.0.4-a
> 
> When that has merged into main and completed the build:
> 
>     Tag the operator-bundle:(version)-pre as (version) eg add 1.0.3 tag to the 1.0.3-pre tag
> 
> This results in:
> 
>     operator-bundle:main which points to operator-bundle:main with a version of 1.0.4-a (can be used in development environments)
>     operator-bundle:main-d which points to the digest of operator-bundle:main with a version of 1.0.4a
>     operator-bundle:1.0.3 which points to the digest of operator:v1.0.3 with a version of 1.0.3 (can be used in production environments)
> 

#165 moves us to 1.0.3 and then this one will move us to 1.0.4-a