### PR TITLE
Add a suffix to the version for the dev build to distinguish it from digest build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,7 +129,7 @@ spec:
                                        cd ../operator
                                        NOORIGIN_BRANCH=${GIT_BRANCH#origin/} # turns origin/master into master
                                        export IMG=quay.io/amlen/operator:$NOORIGIN_BRANCH
-                                       make bundle
+                                       make bundle SUFFIX=-${GIT_BRANCH}
                                        make produce-deployment
                                        pylint --fail-under=5 build/scripts/*.py
                                        cd ../Documentation/doc_infocenter

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,7 +129,8 @@ spec:
                                        cd ../operator
                                        NOORIGIN_BRANCH=${GIT_BRANCH#origin/} # turns origin/master into master
                                        export IMG=quay.io/amlen/operator:$NOORIGIN_BRANCH
-                                       make bundle SUFFIX=-${GIT_BRANCH} | tr '[:upper:]' '[:lower:]'
+                                       export SUFFIX=$(echo "-${GIT_BRANCH}" | tr '[:upper:]' '[:lower:]')
+                                       make bundle SUFFIX=$SUFFIX
                                        make produce-deployment
                                        pylint --fail-under=5 build/scripts/*.py
                                        cd ../Documentation/doc_infocenter

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,7 +129,7 @@ spec:
                                        cd ../operator
                                        NOORIGIN_BRANCH=${GIT_BRANCH#origin/} # turns origin/master into master
                                        export IMG=quay.io/amlen/operator:$NOORIGIN_BRANCH
-                                       make bundle SUFFIX=-${GIT_BRANCH}
+                                       make bundle SUFFIX=-${GIT_BRANCH} | tr '[:upper:]' '[:lower:]'
                                        make produce-deployment
                                        pylint --fail-under=5 build/scripts/*.py
                                        cd ../Documentation/doc_infocenter

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -146,7 +146,7 @@ endif
 bundle: kustomize ## Generate bundle manifests and metadata, then validate generated files.
 	operator-sdk generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
-	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION)$(SUFFIX) $(BUNDLE_METADATA_OPTS)
 	operator-sdk bundle validate ./bundle
 
 .PHONY: bundle-build

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -36,6 +36,10 @@ spec:
         env:
         - name: ANSIBLE_GATHERING
           value: explicit
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['olm.targetNamespaces']
         securityContext:
           allowPrivilegeEscalation: false
         livenessProbe:
@@ -55,7 +59,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 768Mi
+            memory: 1500Mi
           requests:
             cpu: 10m
             memory: 256Mi


### PR DESCRIPTION
We produce two bundles of the operator one that uses digests which allows disconnected installs (airgap) and one that uses tags which is typically for development systems but both had the same version so if you tried t oadd both to a custom catalog they would overwrite each other so you only ended up with the last one added.

Also found another place where we need to specify the memory and watch namespaces (I suspect we have redundant files that need tidying up or can be combined somehow)