### PR TITLE
[patch] only run client activity test when activity is compiled in

### DIFF
--- a/server_proxy/test/proxy_test.c
+++ b/server_proxy/test/proxy_test.c
@@ -101,7 +101,9 @@ void testGetPayload(void);
 void mqttv5_test(void);
 void updateStatsTest(void);
 void pxrouting_test(void);
+#ifdef PX_CLIENTACTIVITY
 void setJSON_test(void);
+#endif
 void stopCrlTest(void);
 void test_kafkaConnection_parse(void);
 void test_mhub_mapper(void);
@@ -144,7 +146,9 @@ CU_TestInfo convert_tests[] = {
     { "--- Testing MQTTv5                    ---", mqttv5_test },
 	{ "--- Testing Proxy Routing             ---", pxrouting_test },
 	{ "--- Testing Tenant                    ---", tenantTest },
+#ifdef PX_CLIENTACTIVITY
 	{ "--- Testing setJSON                   ---", setJSON_test },
+#endif
 	{ "--- Testing stopCRL                   ---", stopCrlTest },
 	{ "--- Testing revalidateSaveData        ---", testRevalidateSaveData },
 	{ "--- Testing mhub_kafkaConnection      ---", test_kafkaConnection_parse },
@@ -418,7 +422,7 @@ void clientClassTest(void) {
     CU_ASSERT(match == 1);
 
 }
-
+#ifdef PX_CLIENTACTIVITY
 void setJSON_test(void) {
     int rc = 0;
     char json[1000];
@@ -443,6 +447,7 @@ void setJSON_test(void) {
         CU_ASSERT(rc == 0);
     }
 }
+#endif
 
 /*
  * call convertTopic


### PR DESCRIPTION
Now we disable client activity by default - we are seeing an issue in a test that is still run when it is disabled