### PR TITLE
OpenSSL 3.0 Support : Replaced RSA with EVP_PKEY in LTPA utils

### DIFF
--- a/server_admin/src/ltpautils.c
+++ b/server_admin/src/ltpautils.c
@@ -291,6 +291,8 @@ static int ism_security_ltpaConvertRSAKeys(
         }
 
         if ((LTPA_LENLEN + padByte + LTPA_DLEN + pubExpLen + 1 + LTPA_PLEN + 1 + LTPA_QLEN) != privKeyLen) {
+            (void) RSA_free(*rsa);
+            *rsa = NULL;
             ism_common_free(ism_memory_admin_misc,*rsaMod);
             *rsaMod = NULL;
             *rsaModLen = 0;

--- a/server_admin/src/ltpautils.c
+++ b/server_admin/src/ltpautils.c
@@ -29,7 +29,7 @@
 
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 #include <openssl/param_build.h>
-#else
+#endif
 
 /* LTPA Key structure with parsed contents from LTPA key file */
 struct ismLTPA_t {
@@ -199,7 +199,7 @@ static int ism_security_ltpaConvertRSAKeys(
     size_t        pubKeyLen,
     char          *privKey,
     size_t        privKeyLen,
-    RSA           **rsa;
+    RSA           **rsa,
     unsigned char **rsaMod,
     size_t        *rsaModLen)
 {
@@ -310,16 +310,16 @@ static int ism_security_ltpaConvertRSAKeys(
             return rc;
         }
 
-//#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         (*rsa)->n = n;
         (*rsa)->d = d;
         (*rsa)->e = e;
         (*rsa)->p = p;
         (*rsa)->q = q;
-/* #else
+#else
         RSA_set0_key((*rsa), n, e, d);
         RSA_set0_factors((*rsa), p, q);
-#endif */
+#endif
 
         rc = ISMRC_OK;
     }

--- a/server_admin/src/ltpautils.c
+++ b/server_admin/src/ltpautils.c
@@ -234,8 +234,6 @@ static int ism_security_ltpaConvertRSAKeys(
         BIGNUM * d = BN_bin2bn((const unsigned char *) (privKey + LTPA_LENLEN + padByte), LTPA_DLEN, NULL);
         if (d == NULL) {
             TRACE(7, "BN_bin2bn failed for rsa->d\n");
-            //(void) RSA_free(*rsa);
-            //*rsa = NULL;
             ism_common_free(ism_memory_admin_misc,*rsaMod);
             *rsaMod = NULL;
             *rsaModLen = 0;

--- a/server_admin/src/ltpautils.c
+++ b/server_admin/src/ltpautils.c
@@ -1595,7 +1595,7 @@ XAPI int ism_security_ltpaDeleteKey(
         ism_common_free(ism_memory_admin_misc,key->realm);
 
     if (key->pkey)
-        EVP_PKEY_free(pkey)(key->pkey);
+        EVP_PKEY_free(key->pkey);
 
     if (key->rsaModLen > 0 && key->rsaMod)
         ism_common_free(ism_memory_admin_misc,key->rsaMod);

--- a/server_admin/src/ltpautils.c
+++ b/server_admin/src/ltpautils.c
@@ -26,7 +26,10 @@
 #include <openssl/evp.h>
 #include <openssl/bio.h>
 #include <openssl/rsa.h>
+
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
 #include <openssl/param_build.h>
+#else
 
 /* LTPA Key structure with parsed contents from LTPA key file */
 struct ismLTPA_t {


### PR DESCRIPTION
couple of openSSL APIs deprecated in openSSL3.0 (in ubi9 image), as of now those are exposed but sooner or later we won't see those.
This PR contains code change towards that for LTPA util file, where I've replaced RSA key with EVP_PKEY and couple of other deprecated APIs (eg. RSA_new and RSA_private_encrypt) replaced with newly introduced APIs using EVP_PKEY.