### PR TITLE
[patch] ensure operator gets amlens out of maintenance

### DIFF
--- a/operator/roles/amlen/library/configure.py
+++ b/operator/roles/amlen/library/configure.py
@@ -271,6 +271,7 @@ def configureHA(server1, server2, groupName):
             logger.warn(content)
         
         server2.clean_store()
+        server2.switch_to_production_mode()
 
         if not server2.check_ha_status():
             logger.error("Error configuring HA for Amlen server %s" % (server2.server_name)) 
@@ -348,10 +349,12 @@ def configureHA(server1, server2, groupName):
     if ok == False:
         # Restart both servers and try again
         logger.warn("Initial HA synchronization failed, restarting server1")
-        server1.restart()
+        server1.restart(maintenance="stop")
+
         if server2 != None:
             logger.warn("Initial HA synchronization failed, restarting server2")
-            server2.restart()
+            server2.restart(maintenance="stop")
+
         ok = server1.check_ha_status()
         
         if ok == False:


### PR DESCRIPTION
We see occasional failures in testing the operator. I think it is because there is a short window where the operator puts a server into maintenance mode and if the operator is restarted/fails in that window it doesn't try to take it out of maintenance mode.

This change means that the operator attempts to move servre in maintenance into production mode