### PR TITLE
Switch from cluster roles to roles

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.1.4
+VERSION ?= 1.1.5
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/operator/config/manifests/bases/eclipse-amlen-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/eclipse-amlen-operator.clusterserviceversion.yaml
@@ -32,13 +32,13 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Streaming & Messaging
-    containerImage: quay.io/amlen/operator:v1.1.4
+    containerImage: quay.io/amlen/operator:v1.1.5
     createdAt: "2022-11-24T15:31:00Z"
     description: An operator to run the Eclipse Amlen MQTT Broker
     operators.operatorframework.io/builder: operator-sdk-v1.25.2
     operators.operatorframework.io/project_layout: ansible.sdk.operatorframework.io/v1
     repository: https://github.com/eclipse/amlen
-  name: eclipse-amlen-operator.v1.1.4
+  name: eclipse-amlen-operator.v1.1.5
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -207,7 +207,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/amlen/operator:v1.1.4
+                image: quay.io/amlen/operator:v1.1.5
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -292,4 +292,4 @@ spec:
   provider:
     name: Eclipse Amlen
     url: https://eclipse.org/amlen
-  version: 1.1.4
+  version: 1.1.5

--- a/operator/config/rbac/amlen_editor_role.yaml
+++ b/operator/config/rbac/amlen_editor_role.yaml
@@ -1,6 +1,6 @@
 # permissions for end users to edit amlens.
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: amlen-editor-role
 rules:

--- a/operator/config/rbac/amlen_viewer_role.yaml
+++ b/operator/config/rbac/amlen_viewer_role.yaml
@@ -1,6 +1,6 @@
 # permissions for end users to view amlens.
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: amlen-viewer-role
 rules:

--- a/operator/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/operator/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: metrics-reader
 rules:

--- a/operator/config/rbac/auth_proxy_role.yaml
+++ b/operator/config/rbac/auth_proxy_role.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: proxy-role
 rules:

--- a/operator/config/rbac/auth_proxy_role_binding.yaml
+++ b/operator/config/rbac/auth_proxy_role_binding.yaml
@@ -1,10 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: proxy-role
 subjects:
 - kind: ServiceAccount

--- a/operator/config/rbac/kustomization.yaml
+++ b/operator/config/rbac/kustomization.yaml
@@ -2,7 +2,7 @@ resources:
 # All RBAC will be applied under this service account in
 # the deployment namespace. You may comment out this resource
 # if your manager will use a service account that exists at
-# runtime. Be sure to update RoleBinding and ClusterRoleBinding
+# runtime. Be sure to update RoleBinding
 # subjects if changing service account names.
 - service_account.yaml
 - role.yaml

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: manager-role
 rules:

--- a/operator/config/rbac/role_binding.yaml
+++ b/operator/config/rbac/role_binding.yaml
@@ -1,10 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: manager-role
 subjects:
 - kind: ServiceAccount

--- a/operator/config/testing/kustomization.yaml
+++ b/operator/config/testing/kustomization.yaml
@@ -10,7 +10,8 @@ namePrefix: osdk-
 patchesStrategicMerge:
 - manager_image.yaml
 - debug_logs_patch.yaml
-- ../default/manager_auth_proxy_patch.yaml
+# Commented out to remove kube-rbac-proxy dependency (see commit 1eae0e1e)
+#- ../default/manager_auth_proxy_patch.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/operator/config/testing/kustomization.yaml
+++ b/operator/config/testing/kustomization.yaml
@@ -10,7 +10,6 @@ namePrefix: osdk-
 patchesStrategicMerge:
 - manager_image.yaml
 - debug_logs_patch.yaml
-- watch_namespace_patch.yaml
 # Commented out to remove kube-rbac-proxy dependency (see commit 1eae0e1e)
 #- ../default/manager_auth_proxy_patch.yaml
 
@@ -26,3 +25,7 @@ images:
   newTag: main
 patches:
 - path: pull_policy/Always.yaml
+- path: watch_namespace_patch.yaml
+  target:
+    kind: Deployment
+    name: controller-manager

--- a/operator/config/testing/kustomization.yaml
+++ b/operator/config/testing/kustomization.yaml
@@ -10,6 +10,7 @@ namePrefix: osdk-
 patchesStrategicMerge:
 - manager_image.yaml
 - debug_logs_patch.yaml
+- watch_namespace_patch.yaml
 # Commented out to remove kube-rbac-proxy dependency (see commit 1eae0e1e)
 #- ../default/manager_auth_proxy_patch.yaml
 
@@ -25,7 +26,3 @@ images:
   newTag: main
 patches:
 - path: pull_policy/Always.yaml
-- path: watch_namespace_patch.yaml
-  target:
-    kind: Deployment
-    name: controller-manager

--- a/operator/config/testing/kustomization.yaml
+++ b/operator/config/testing/kustomization.yaml
@@ -10,6 +10,7 @@ namePrefix: osdk-
 patchesStrategicMerge:
 - manager_image.yaml
 - debug_logs_patch.yaml
+- watch_namespace_patch.yaml
 # Commented out to remove kube-rbac-proxy dependency (see commit 1eae0e1e)
 #- ../default/manager_auth_proxy_patch.yaml
 

--- a/operator/config/testing/watch_namespace_patch.yaml
+++ b/operator/config/testing/watch_namespace_patch.yaml
@@ -1,16 +1,7 @@
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: controller-manager
-  namespace: system
-spec:
-  template:
-    spec:
-      containers:
-        - name: manager
-          env:
-            - name: WATCH_NAMESPACE
-              value: "osdk-test"
+- op: replace
+  path: /spec/template/spec/containers/0/env/1
+  value:
+    name: WATCH_NAMESPACE
+    value: "osdk-test"
 
 # Made with Bob

--- a/operator/config/testing/watch_namespace_patch.yaml
+++ b/operator/config/testing/watch_namespace_patch.yaml
@@ -1,7 +1,17 @@
-- op: replace
-  path: /spec/template/spec/containers/0/env/1
-  value:
-    name: WATCH_NAMESPACE
-    value: "osdk-test"
-
-# Made with Bob
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          env:
+            - $patch: replace
+            - name: ANSIBLE_GATHERING
+              value: explicit
+            - name: WATCH_NAMESPACE
+              value: "osdk-test"

--- a/operator/config/testing/watch_namespace_patch.yaml
+++ b/operator/config/testing/watch_namespace_patch.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+
+# Made with Bob

--- a/operator/config/testing/watch_namespace_patch.yaml
+++ b/operator/config/testing/watch_namespace_patch.yaml
@@ -11,8 +11,6 @@ spec:
         - name: manager
           env:
             - name: WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
+              value: "osdk-test"
 
 # Made with Bob


### PR DESCRIPTION
The operator should be using Roles not ClusterRoles, this fixes permissions for when running in namespace, this does mean to run in cluster scope there is an extra step, and we will have to document that in the community operator hub before we do a public release (I can't remember what version that is on I'm fairly confident we didn't do a release for 1.1.4 maybe we did for 1.1.3)

as molecule doesn't understand OLM it requires a patch to tell it which namespace to run against.